### PR TITLE
Dynamic Problem Selection and Input view loading - DPTU-41

### DIFF
--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -463,4 +463,12 @@ public class LCSProblem extends Problem {
          System.out.println("------------------------");
     }
 
+    public String getX() {
+        return x;
+    }
+
+    public String getY() {
+        return y;
+    }
+
 }

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -81,6 +81,20 @@ public class TutoringSession {
         this.student = student;
         tasks = new ArrayList<>();
     }
+
+    /**
+     * Initialize this session with an Account and a Problem. 
+     * This constructor creates a new Student object from the Account.
+     * 
+     * @param account the Account used to create the Student.
+     * @param problem the Problem to be solved in this session.
+     * @author EverettCV
+     */
+    public TutoringSession(Account account, Problem problem) {
+        this.student = new Student(account);  // Create a new Student from Account
+        this.problem = problem;
+        this.tasks = new ArrayList<>();  // Initialize tasks list
+    }
     
      public int getId() {
         return id;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -8,6 +8,7 @@ import edu.regis.dptu.util.CustomProgressBar;
 import edu.regis.dptu.view.act.PracticeAction;
 import edu.regis.dptu.view.act.QuizMeAction;
 import edu.regis.dptu.view.act.TeachMeAction;
+import edu.regis.dptu.model.TaskKind;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -16,6 +17,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridLayout;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComboBox; // Added for problem selector
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -25,7 +27,7 @@ import javax.swing.border.EmptyBorder;
 public class DashboardPanel extends GPanel {
     private TutoringSession model;
     private static boolean welcome = false;
- 
+
     private JButton logOutButton;
     private JButton settingsButton;
     private JButton teachMeButton;
@@ -35,6 +37,9 @@ public class DashboardPanel extends GPanel {
     private CustomProgressBar practiceProgressBar;
     private CustomProgressBar quizMeProgressBar;
     private JLabel welcomeLabel;
+
+    // ADDED: Problem selector combo box
+    private JComboBox<String> problemSelector; // @author EverettCV
 
     public DashboardPanel(TutoringSession tutoringSession) {
         model = tutoringSession;
@@ -57,7 +62,7 @@ public class DashboardPanel extends GPanel {
         initializeComponents();
         layoutComponents();
     }
-    
+
     public void setModel(TutoringSession model) {
         this.model = model;
     }
@@ -106,20 +111,34 @@ public class DashboardPanel extends GPanel {
 
         quizMeButton = new JButton(QuizMeAction.instance());
         quizMeButton.setFocusPainted(false);
+
+        // ADDED: Problem selector dropdown for choosing problem type (LCS, Matrix, Knapsack)
+        problemSelector = new JComboBox<>(new String[]{
+            "Longest Common Subsequence",
+            "Matrix Chain Multiplication",
+            "Knapsack Problem"
+        });
+        problemSelector.setSelectedIndex(0); // Default to LCS
+
+        // TODO: Hook this selection into TeachMeAction, PracticeAction, QuizMeAction
+        // TODO: Replace String-based selection with a proper ProblemType enum for clean future-proofing
     }
 
     private void layoutComponents() {
         setLayout(new BorderLayout());
-        
+
         // Top panel with settings, welcome message, and logout
         JPanel topPanel = new JPanel(new BorderLayout());
         topPanel.setBackground(new Color(0, 43, 73));
         topPanel.setBorder(new EmptyBorder(5, 10, 5, 10));
-        
+
         topPanel.add(settingsButton, BorderLayout.WEST);
         topPanel.add(welcomeLabel, BorderLayout.CENTER);
         topPanel.add(logOutButton, BorderLayout.EAST);
-        
+
+        // ADDED: Attach problem selector below the welcome message
+        topPanel.add(problemSelector, BorderLayout.SOUTH);
+
         add(topPanel, BorderLayout.NORTH);
 
         // Main content panel with three columns
@@ -151,19 +170,19 @@ public class DashboardPanel extends GPanel {
         JPanel progressPanel = new JPanel(new BorderLayout());
         progressPanel.setBackground(new Color(0, 43, 73));
         progressPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
-        
+
         // Make progress bar fill the space while maintaining aspect ratio
         progressBar.setPreferredSize(new Dimension(100, 400));
         progressPanel.add(progressBar, BorderLayout.CENTER);
-        
+
         column.add(progressPanel, BorderLayout.CENTER);
-        
+
         // Button panel at the bottom
         JPanel buttonPanel = new JPanel(new BorderLayout());
         buttonPanel.setBackground(new Color(0, 43, 73));
         buttonPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
         buttonPanel.add(button, BorderLayout.CENTER);
-        
+
         column.add(buttonPanel, BorderLayout.SOUTH);
 
         return column;
@@ -179,5 +198,23 @@ public class DashboardPanel extends GPanel {
 
     private void logOutButtonActionPerformed(java.awt.event.ActionEvent evt) {
         SplashFrame.instance().logout();
+    }
+
+    /**
+     * Return the TaskKind corresponding to the currently selected problem in the dropdown.
+     * @return TaskKind @author EverettCV
+     */
+    public TaskKind getSelectedTaskKind() {
+        int index = problemSelector.getSelectedIndex();
+        switch (index) {
+            case 0:
+                return TaskKind.LCS_PROBLEM;
+            case 1:
+                return TaskKind.MATRIX_CHAIN;
+            case 2:
+                return TaskKind.KNAPSACK_0_1;
+            default:
+                return TaskKind.LCS_PROBLEM; // Fallback
+        }
     }
 }

--- a/src/main/java/edu/regis/dptu/view/MatrixInputView.java
+++ b/src/main/java/edu/regis/dptu/view/MatrixInputView.java
@@ -18,7 +18,7 @@ import javax.swing.JTextField;
 * LCSInputView.java
 */
 public class MatrixInputView extends JPanel {
-    public MatrixInputView() {
+    public MatrixInputView(TutoringSessionView parentView) {
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.insets = new Insets(8, 8, 8, 8);

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -2,14 +2,18 @@ package edu.regis.dptu.view;
 
 import java.awt.BorderLayout;
 import javax.swing.JPanel;
+import edu.regis.dptu.model.TaskKind;
+import edu.regis.dptu.model.Problem;
 
 /**
  * Displays the appropriate input view depending on the selected problem type.
  * 
- * Changes (April 17, 2025):
- * - Currently only supports LCSInputView because LCS is the only finished problem type.
- * - MatrixInputView and KnapsackInputView are scaffolded as commented-out placeholders
- *   for future development.
+ * Updated April 30, 2025:
+ * - Dynamically loads the correct input panel based on the Problem's TaskKind.
+ * - Supports LCSInputView and MatrixInputView.
+ * - KnapsackInputView is scaffolded for future use.
+ * - Added null model fallback to avoid initialization errors when model not yet set.
+ * 
  * @author EverettCV
  */
 public class ProblemInputView extends JPanel {
@@ -20,18 +24,42 @@ public class ProblemInputView extends JPanel {
         this.parentView = parentView;
         setLayout(new BorderLayout());
 
-        // Currently only load LCSInputView since only LCS problem is ready
-        LCSInputView lcsInputView = new LCSInputView(parentView);
-        add(lcsInputView, BorderLayout.CENTER);
+        // Safely get the problem from the parent model (can be null during early initialization)
+        Problem problem = (parentView.getModel() != null) ? parentView.getModel().getProblem() : null;
 
-        // TODO: Uncomment and dynamically load the appropriate input view
-        //       once ProblemType selection and switching is implemented.
+        // If no model/problem exists yet, fallback to LCSInputView by default
+        if (problem == null) {
+            System.out.println("No TutoringSession or Problem found. Defaulting to LCSInputView.");
+            LCSInputView lcsInputView = new LCSInputView(parentView);
+            add(lcsInputView, BorderLayout.CENTER);
+            return;
+        }
 
-        // Example placeholders for future input views:
-        // MatrixInputView matrixInputView = new MatrixInputView();
-        // add(matrixInputView, BorderLayout.CENTER);
+        // Otherwise, dynamically load the correct input view based on the Problem's TaskKind
+        TaskKind kind = problem.getKind();
 
-        // KnapsackInputView knapsackInputView = new KnapsackInputView();
-        // add(knapsackInputView, BorderLayout.CENTER);
+        switch (kind) {
+            case LCS_PROBLEM:
+                LCSInputView lcsInputView = new LCSInputView(parentView);
+                add(lcsInputView, BorderLayout.CENTER);
+                break;
+
+            case MATRIX_CHAIN:
+                MatrixInputView matrixInputView = new MatrixInputView(parentView);
+                add(matrixInputView, BorderLayout.CENTER);
+                break;
+
+            case KNAPSACK_0_1:
+                // TODO: Uncomment and load KnapsackInputView once KnapsackProblem and its view are implemented:
+                // KnapsackInputView knapsackInputView = new KnapsackInputView();
+                // add(knapsackInputView, BorderLayout.CENTER);
+                System.out.println("Knapsack input view not yet implemented.");
+                break;
+
+            default:
+                System.out.println("Unrecognized problem type. Defaulting to LCS input view.");
+                LCSInputView defaultView = new LCSInputView(parentView);
+                add(defaultView, BorderLayout.CENTER);
+        }
     }
 }

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -15,6 +15,11 @@ package edu.regis.dptu.view;
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.model.User;
+import edu.regis.dptu.model.TaskKind;
+import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.MatrixChainProblem;
+// Import Knapsack problem once implemented and update the switch statement below.
+import edu.regis.dptu.model.Problem;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 import javax.swing.JButton;
@@ -307,4 +312,60 @@ public class SplashFrame extends JFrame {
         lessonSessionView = new LessonSessionView();
         //cards.add(lessonSessionView, LESSON);
     }
+
+    /**
+     * Basic getter for the dashboardPanel
+     * @return the DashboardPanel instance currently used in the SplashFrame
+     * @author EverettCV
+     */
+    public DashboardPanel getDashboardPanel() {
+        return dashboardPanel;
+    }
+
+    /**
+     * Select the lesson screen for the given problem type (TaskKind). 
+     * Creates a new TutoringSession with the appropriate Problem. @author EverettCV
+     */
+    public void selectLessonScreen(TaskKind kind) {
+
+        // Step 1: Create the correct Problem subclass based on TaskKind
+        Problem problem;
+
+        switch (kind) {
+            case LCS_PROBLEM:
+                problem = new LCSProblem("skullandbones", "lullabybabies");
+                break;
+            case MATRIX_CHAIN:
+                problem = new MatrixChainProblem(new int[][]{
+                    {10, 20},
+                    {20, 30},
+                    {30, 40}
+                });  // default values, can be changed to whatever
+                break;
+            case KNAPSACK_0_1:
+                //problem = new KnapsackProblem(new int[]{1, 2, 3}, new int[]{6, 10, 12}, 5); Once the KnapsackProblem.java is implemented, uncomment this to allow them to select it
+                System.out.println("KnapsackProblem not yet implemented. Defaulting to LCSProblem");
+                problem = new LCSProblem("skullandbones", "lullabybabies");
+                break;
+            default:
+                // Fallback to LCS if somehow another TaskKind got through
+                problem = new LCSProblem("skullandbones", "skullandbones");
+                break;
+        }
+
+        // Create or update the TutoringSession
+        if (this.tutoringSession == null) {
+            this.tutoringSession = new TutoringSession(getAccount(), problem);
+        } else {
+            // Reuse the account, but replace the problem
+            this.tutoringSession = new TutoringSession(this.tutoringSession.getStudent().getAccount(), problem);
+        }
+
+        // Pass the new session to the MainFrame
+        MainFrame.instance().setModel(tutoringSession);
+
+        // Show the MainFrame (lesson view)
+        MainFrame.instance().setVisible(true);
+    }
+
 }

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -14,7 +14,10 @@ package edu.regis.dptu.view;
 
 import edu.regis.dptu.model.LCSProblem; // Needed for creating the initial problem
 import edu.regis.dptu.model.Problem;   // Needed for type consistency
+import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.model.TutoringSession;
+
+import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import javax.swing.JLabel;
 
@@ -55,7 +58,7 @@ public class TutoringSessionView extends GPanel {
     public TutoringSession getModel() { return model; }
     public SubproblemTableView getTableView() { return tableView; }
     public StepCompletionView getStepCompletionView() { return null; }
-    public StepSelectorView getStepSelectorView() { return null; }
+    //public StepSelectorView getStepSelectorView() { return null; }
 
     /**
      * This is a stub method that will be implemented later when we add StepSelectorView.
@@ -147,7 +150,9 @@ public class TutoringSessionView extends GPanel {
      * Layout the child components in this view using **ORIGINAL** constraints.
      */
     private void layoutComponents() {
-        addc(problemInputView, 0, 0, 2, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,  5, 5, 5); 
+        // TODO: Consider dynamic layout switching to avoid LCS-specific views showing for non-LCS problems.
+
+        addc(problemInputView, 0, 0, 2, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,  5, 5, 5, 5); 
         addc(codeView, 0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, 5, 5, 5, 5);
         // ToDo: Is tableView and subproblemView trying to do the same thing?
         addc(tableView, 1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.SOUTH, GridBagConstraints.HORIZONTAL, 5, 5, 5, 5); // Original
@@ -178,7 +183,8 @@ public class TutoringSessionView extends GPanel {
      * **FUNCTIONAL CHANGE:** Ensures all views needing the model receive it.
      */
     private void updateView() {
-         System.out.println("DEBUG: TutoringSessionView.updateView called.");
+        System.out.println("DEBUG: TutoringSessionView.updateView called.");
+
         if (model == null) {
             System.out.println("DEBUG: TutoringSessionView.updateView: Main session model is null. Setting child models to null.");
             // Set models to null if session model is null
@@ -189,28 +195,90 @@ public class TutoringSessionView extends GPanel {
             return;
         }
 
-
         Problem currentProblem = model.getProblem();
-        System.out.println("DEBUG: TutoringSessionView.updateView: Current problem from session: " + (currentProblem != null ? Integer.toHexString(currentProblem.hashCode()) : "null"));
+        System.out.println("DEBUG: TutoringSessionView.updateView: Current problem from session: " + 
+            (currentProblem != null ? Integer.toHexString(currentProblem.hashCode()) : "null"));
 
+        // Update views depending on Problem type
+        TaskKind kind = currentProblem.getKind();
+        System.out.println("DEBUG: TaskKind is " + kind);
 
-        // *** Pass the current problem to all relevant views ***
-        stepViewPanel.setModel(currentProblem);
-        codeView.setModel(currentProblem);
-        variablesView.setModel(currentProblem);
-        tableView.setModel(currentProblem); // <<< Ensure tableView gets the model
+        switch (kind) {
+            case LCS_PROBLEM:
+                System.out.println("DEBUG: LCSProblem detected. Passing model to views.");
 
+                // Pass the current problem to all relevant LCS views
+                stepViewPanel.setModel(currentProblem);
+                codeView.setModel(currentProblem);
+                variablesView.setModel(currentProblem);
+                tableView.setModel(currentProblem); 
 
-        // Original commented out updates
-        /* if (model.currentTask() != null) { stepSelectorView.setTask(model.currentTask().getTask()); } */
+                // Subsequence View - update and show
+                subSeqView.updateWords(
+                    ((LCSProblem) currentProblem).getX(),
+                    ((LCSProblem) currentProblem).getY()
+                );
+                subSeqView.setVisible(true);
 
+                // Make sure all views are visible
+                stepViewPanel.setVisible(true);
+                codeView.setVisible(true);
+                variablesView.setVisible(true);
+                tableView.setVisible(true);
+
+                break;
+
+            case MATRIX_CHAIN:
+                System.out.println("DEBUG: MatrixChainProblem detected. Clearing LCS views.");
+
+                // LCS views should not display anything for Matrix problems
+                stepViewPanel.setModel(null);
+                codeView.setModel(null);
+                variablesView.setModel(null);
+                tableView.setModel(null);
+
+                stepViewPanel.setVisible(false);
+                codeView.setVisible(false);
+                variablesView.setVisible(false);
+                tableView.setVisible(false);
+                subSeqView.setVisible(false);  // Hide Subsequence view too
+
+                // TODO: Eventually create Matrix-specific step/code/table views,
+                // you can add logic here to pass the currentProblem to those views
+                break;
+
+            default:
+                System.out.println("DEBUG: Unrecognized TaskKind. Clearing views.");
+                stepViewPanel.setModel(null);
+                codeView.setModel(null);
+                variablesView.setModel(null);
+                tableView.setModel(null);
+
+                stepViewPanel.setVisible(false);
+                codeView.setVisible(false);
+                variablesView.setVisible(false);
+                tableView.setVisible(false);
+                subSeqView.setVisible(false);
+                break;
+        }
+
+        // Rebuild the correct ProblemInputView
+        if (problemInputView != null) {
+            remove(problemInputView);
+        }
+
+        problemInputView = new ProblemInputView(this); // Recreate it fresh based on the problem
+        addc(problemInputView, 0, 0, 2, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,  5, 5, 5, 5);
 
         // Refresh layout after potentially changing models
         revalidate();
         repaint();
     }
 
+
+
     void setModel(TutoringSession model) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
+        this.model = model;
+        updateView();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/TeachMeAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachMeAction.java
@@ -12,7 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.view.MainFrame;
+import edu.regis.dptu.view.SplashFrame;
+import edu.regis.dptu.view.DashboardPanel;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import static javax.swing.Action.MNEMONIC_KEY;
@@ -31,15 +35,31 @@ public class TeachMeAction extends DpTuGuiAction {
 
     private TeachMeAction() {
         super("Teach Me");
-        
+
         putValue(SHORT_DESCRIPTION, "Start a teaching session");
         putValue(MNEMONIC_KEY, KeyEvent.VK_T);
     }
 
+    /**
+     * @author EverettCV
+     */
     @Override
     public void actionPerformed(ActionEvent evt) {
-        MainFrame frame = MainFrame.instance();
-        frame.setVisible(true);
-        // TODO: Add tutor notification in future sprint
+
+        // Get the DashboardPanel from the SplashFrame
+        DashboardPanel dashboard = SplashFrame.instance().getDashboardPanel();
+
+        if (dashboard == null) {
+            System.err.println("DashboardPanel not initialized. Defaulting to LCS_PROBLEM.");
+            SplashFrame.instance().selectLessonScreen(TaskKind.LCS_PROBLEM);
+            return;
+        }
+
+        // Get the selected TaskKind from the DashboardPanel
+        TaskKind selectedKind = dashboard.getSelectedTaskKind();
+        System.out.println("TeachMeAction selected TaskKind: " + selectedKind);
+
+        // Call SplashFrame to transition to the lesson screen with this TaskKind
+        SplashFrame.instance().selectLessonScreen(selectedKind);
     }
 }


### PR DESCRIPTION
	modified:   src/main/java/edu/regis/dptu/model/LCSProblem.java
	modified:   src/main/java/edu/regis/dptu/model/TutoringSession.java
	modified:   src/main/java/edu/regis/dptu/view/DashboardPanel.java
	modified:   src/main/java/edu/regis/dptu/view/MatrixInputView.java
	modified:   src/main/java/edu/regis/dptu/view/ProblemInputView.java
	modified:   src/main/java/edu/regis/dptu/view/SplashFrame.java
	modified:   src/main/java/edu/regis/dptu/view/TutoringSessionView.java
	modified:   src/main/java/edu/regis/dptu/view/act/TeachMeAction.java

    Implement dynamic problem selection & input view loading (LCS / Matrix Chain)

    Summary:
    ---------
    - Users can now select a problem type (LCS or Matrix Chain) from the dashboard before starting a session.
    - Teach Me action now launches a TutoringSession using the selected Problem.
    - ProblemInputView dynamically loads LCSInputView or MatrixInputView depending on the TaskKind.
    - TutoringSessionView dynamically updates views based on the Problem kind:
        - Loads LCS views for LCSProblem.
        - Clears incompatible views for MatrixChainProblem (until Matrix-specific views are created).

    Key changes:
    -------------
    - DashboardPanel: Added problem selector and getter.
    - TeachMeAction: Passes selected TaskKind to SplashFrame.
    - SplashFrame: Creates the appropriate Problem type and initializes a new TutoringSession.
    - TutoringSessionView: updateView() rebuilt to load/clear views based on TaskKind.
    - ProblemInputView: Loads the correct input panel based on TaskKind.

    Future work (TODOs noted in code):
    -----------------------------------
    - ProblemInputView: Activate KnapsackInputView once KnapsackProblem is implemented.
    - TutoringSessionView:
        - When Matrix-specific views are ready (MatrixStepPanel, MatrixCodeView, etc.), load them in updateView().
        - Eventually consider making layoutComponents() dynamically build per-problem layouts to avoid empty LCS views appearing for non-LCS problems.