### PR TITLE
Fixed database issues associated with loading (sub) problems

### DIFF
--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -23,7 +23,7 @@ DROP DATABASE IF EXISTS DpTuDB;
 CREATE DATABASE DpTuDB;
 
 # Create user representing the tutor.
-CREATE USER 'DpTuTs'@'localhost' IDENTIFIED BY 'DpTu2023';
+CREATE USER IF NOT EXISTS 'DpTuTs'@'localhost' IDENTIFIED BY 'DpTu2023';
 
 # Give the DpTuTs tutor the following priveledges.
 GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP ON DpTuDB.* TO 'DpTuTs'@'localhost';
@@ -77,11 +77,8 @@ CREATE TABLE Unit (
       'STUDENT_CHOICE',
       'FIXED_SEQUENCE',
       'MASTERY_LEARNING',
-      'MICROADAPTATION',
-      'OTHER',
-      'ERROR'
+      'MICROADAPTATION'
    ),
-
    PRIMARY KEY(UnitId),
    FOREIGN KEY (CourseId)
       REFERENCES Course(CourseId)
@@ -99,11 +96,11 @@ CREATE TABLE TutoringSession (
    UnitId INT NOT NULL,
    IsActive BOOLEAN DEFAULT false,
    StartDate TIMESTAMP NOT NULL,
-   ProblemKind ENUM (
+   ProblemType ENUM (
     'LCS_PROBLEM',
     'MATRIX_CHAIN',
     'KNAPSACK_0_1'
-  ),
+   ),
    ProblemId INT NOT NULL,
 
    PRIMARY KEY (SessionId),
@@ -116,6 +113,8 @@ CREATE TABLE TutoringSession (
 );
 
 # KindId is an index into the appropriate table identified by Kind.
+# For example, if the Kind is PROBLEM, then the KindId is the id of the
+# problem in the Problem table.
 CREATE TABLE Task (
   TaskId int NOT NULL DEFAULT 0,
   CourseId int NOT NULL DEFAULT 1,
@@ -124,9 +123,7 @@ CREATE TABLE Task (
   Title varchar(256) NOT NULL,
   Description varchar(256) NOT NULL,
   Kind ENUM(
-      'LCS_PROBLEM',
-      'MATRIX_CHAIN',
-      'KNAPSACK_0_1',
+      'PROBLEM',
       'INITIALIZE_FIRST_ROW',
       'INITIALIZE_FIRST_COL',
       'ASSIGN_CELL',
@@ -137,6 +134,8 @@ CREATE TABLE Task (
   KindId int,
   PRIMARY KEY (TaskId));
 
+# SubTypeId is determined by the StepSubType. For example, for a PROBLEM_REVIEW,
+# the SubTypeId is an id of a problem in the Problem table
 CREATE TABLE Step (
   Id int NOT NULL,
   CourseId int NOT NULL,
@@ -158,6 +157,21 @@ CREATE TABLE Step (
   TimeoutId int,
   PRIMARY KEY (Id));
 
+CREATE TABLE Hint (
+  Id int NOT NULL DEFAULT '0',
+  StepId int NOT NULL,
+  Text varchar(256) DEFAULT NULL,
+  SequenceIndex int DEFAULT NULL,
+  PRIMARY KEY (Id));
+
+CREATE TABLE Timeout (
+  id int NOT NULL,
+  TimeoutType varchar(256),
+  Seconds int,
+  Event varchar(256),
+  Msg varchar(4096),
+  PRIMARY KEY(id));
+
 CREATE TABLE PendingTask (
   SessionId int NOT NULL,
   TaskId int NOT NULL,
@@ -174,21 +188,7 @@ CREATE TABLE PendingStep (
   CurrentHintIndex int NOT NULL
 );
 
-CREATE TABLE LCSProblem (
-  Id int NOT NULL,
-  Title VARCHAR(256),
-  Description VARCHAR(256),
-  Sequence1 VARCHAR(256),
-  Sequence2 VARCHAR(256)
-);
 
-CREATE TABLE Timeout (
-  id int NOT NULL,
-  TimeoutType varchar(256),
-  Seconds int,
-  Event varchar(256),
-  Msg varchar(4096),
-  PRIMARY KEY(id));
 
 CREATE TABLE KnowledgeComponent (
   Id int NOT NULL ,
@@ -210,13 +210,6 @@ CREATE TABLE ExercisingLocation (
   StepId int,
   PRIMARY KEY (Id));
 
-CREATE TABLE Hint (
-  Id int NOT NULL DEFAULT '0',
-  StepId int NOT NULL,
-  Text varchar(256) DEFAULT NULL,
-  SequenceIndex int DEFAULT NULL,
-  PRIMARY KEY (Id));
-
 CREATE TABLE Assessment (
    Id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
    UserId VARCHAR(256) NOT NULL,
@@ -227,36 +220,58 @@ CREATE TABLE Assessment (
    Hints INT
 );
 
+# If ProblemType is LCS_PROBLEM, then SubTypeId is the id of the problem in
+# the LCSProblem table
+CREATE TABLE Problem (
+  Id INT NOT NULL,
+  ProblemType ENUM (
+    'LCS_PROBLEM',
+    'MATRIX_CHAIN',
+    'KNAPSACK_0_1'
+  ),
+  SubTypeId INT NOT NULL,
+  Title VARCHAR(256),
+  Description VARCHAR(256),
+  PRIMARY KEY (Id)
+); 
+
+CREATE TABLE LCSProblem (
+  Id int NOT NULL,
+  Sequence1 VARCHAR(256),
+  Sequence2 VARCHAR(256),
+  PRIMARY KEY (Id)
+);
+
+
+#
+#
+#
+#
+#
+
 INSERT INTO Course
-(CourseId,
- Title,
- PrimaryPedagogy,
- Description)
+  (CourseId, Title, PrimaryPedagogy, Description)
 VALUES
-(1,'Longest Common Subsequence DP', 'FIXED_SEQUENCE', 
-  'Familiarizes students with the Dynamic Programming Paradigm
-   using Longest Common Subseqeunce problem examples.');
+  (1,'Dynamic Programming', 'FIXED_SEQUENCE', 
+  'Familiarizes students with the Dynamic Programming Paradigm.');
 
 INSERT INTO Unit
-(
-CourseId,
-Title,
-Description,
-SequenceIndex,
-Pedagogy)
+  (CourseId, Title, Description, SequenceIndex, Pedagogy)
 VALUES
-(1, 'LCS: See One', 
+  (1, 'LCS: See One', 
   'In this unit, the student will see an example of a Dynamic Programming
-   approach that solves a Longest Common Subsequence problem for two
+   approach that solves a Longest Common Subsequence (LCS) problem for two
    string sequences.', 
     0, 'FIXED_SEQUENCE');
 
-INSERT INTO LCSProblem
- (Id, Title, Description, Sequence1, Sequence2)
+INSERT INTO Task
+ (TaskId, CourseId, UnitId, SequenceIndex, Title,
+  Description,
+  Kind, KindId)
  VALUES
- (0, 'Longest Common Subsequence Example 1',
-  'Determine the longests common subsequence for the given sequences/strings.',
-  'skullandbones', 'lullabybabies');
+ (0, 1, 1, 0, 'Problem Overview', 
+  'Review the presentation of the current Dynamic Programming problem', 
+  'PROBLEM', 0);
 
 INSERT INTO Step 
  (Id, CourseId, UnitId, TaskId, SequenceIndex,
@@ -267,26 +282,15 @@ INSERT INTO Step
   SubTypeId, TimeoutId)
  VALUES
  (0, 1, 0, 0, 0,
-  'Review Problem', 'Acknowledge understanding of the problem.',
+  'Review Problem', 'Acknowledge understanding of the dynamic programming problem.',
   0, 'PROBLEM_REVIEW', 0, 0);
 
-INSERT INTO Task
- (TaskId, CourseId, UnitId, SequenceIndex, Title,
-  Description,
-  Kind, KindId)
- VALUES
- (0, 1, 1, 0, 'Problem Overview', 
-  'Review the presentation of the current Longest Common Subsequence problem', 
-  'LCS_PROBLEM', 0);
 
 INSERT INTO Timeout (id, TimeoutType, Seconds, Event, Msg) VALUES
  (0, 'Info Message', 360, 'Reminder', 'Please acknowledge you understand the current problem.');
 
 INSERT INTO Hint
-(Id,
- StepId,
- Text,
- SequenceIndex)
+(Id, StepId, Text, SequenceIndex)
 VALUES
 (0, 0, 'Acknowledge this problem review by pressing the ''Acknowledged'' button.', 0);
 
@@ -298,3 +302,15 @@ VALUES
 (0, 1, 'Problem Review Acknowledgement', 
  'Student has appropriately demonstrated acknowleding they understand the current problem.',
  'Application', 0, 'Other', '0', 'Knowledge Component');
+
+
+INSERT INTO Problem
+ (Id, ProblemType, SubTypeId, Title, Description)
+VALUES
+ (0, 'LCS_PROBLEM', 0, 'Longest Common Subsequence Problem 1',
+  'Determine the longests common subsequence for the given sequences/strings.');
+
+INSERT INTO LCSProblem
+ (Id, Sequence1, Sequence2)
+ VALUES
+ (0, 'skullandbones', 'lullabybabies');

--- a/src/main/java/edu/regis/dptu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDAO.java
@@ -21,7 +21,7 @@ import edu.regis.dptu.model.CourseDigest;
 import edu.regis.dptu.model.ExercisingLocation;
 import edu.regis.dptu.model.Hint;
 import edu.regis.dptu.model.KnowledgeComponent;
-import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.Model;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.Step;
 import edu.regis.dptu.model.StepSubType;
@@ -33,6 +33,8 @@ import edu.regis.dptu.model.Unit;
 import edu.regis.dptu.model.UnitDigest;
 import edu.regis.dptu.model.aol.OutcomeGranularity;
 import edu.regis.dptu.svc.CourseSvc;
+import edu.regis.dptu.svc.ProblemSvc;
+import edu.regis.dptu.svc.ServiceFactory;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -190,9 +192,9 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 task.setKind(TaskKind.valueOf(rs.getString(3)));
                 task.setSequenceIndex(rs.getInt(4));
                 
-          
                 task.setSteps(retrieveSteps(courseId, task.getId(), conn));
                 
+                // ToDo, is problem needed in the task versus in the steps
                 // retrieve LCS Problem
 
                 return task;
@@ -317,6 +319,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
         PreparedStatement stmt = null;
         
         int courseId = course.getId();
+        int problemId = Model.DEFAULT_ID;
 
         try {
             stmt = conn.prepareStatement(sql);
@@ -333,7 +336,14 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 task.setKind(TaskKind.valueOf(rs.getString(4)));
                 task.setSequenceIndex(rs.getInt(5));
                 
-                task.setProblem(retrieveProblem(task.getKind(), rs.getInt(6), conn));
+                switch (task.getKind()) {
+                    case PROBLEM:
+                        ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
+                        problemId = rs.getInt(6);
+                        Problem problem = problemSvc.retrieve(problemId);
+                        task.setProblem(problem);
+                        break;
+                }
                 
                 tasks.add(task);
                 
@@ -343,6 +353,9 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
             }
             
             return tasks;
+        } catch (ObjNotFoundException e) {
+            InconsistentDBException ex = new InconsistentDBException("Problem not found in Problem Task Type: " + problemId);
+            throw new NonRecoverableException("Cannot find problem in DB", ex);
         } catch (SQLException e) {
             throw new NonRecoverableException("CourseDAO-ERR-7" + e.toString(), e);
         } finally {
@@ -490,53 +503,6 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
             close(stmt); // Don't close the connection, retrieve(courseId) will
         }
     }
-    
-    private Problem retrieveProblem(TaskKind kind, int kindId, Connection conn) 
-        throws NonRecoverableException {
-        switch (kind) {
-            case LCS_PROBLEM:
-                return retrieveLCSProblem(kindId, conn);
-                
-            default:
-                return null;
-        }
-    }
-    
-    private LCSProblem retrieveLCSProblem(int kindId, Connection conn) throws NonRecoverableException {
-         final String sql = "SELECT Title,Description,Sequence1,Sequence2 FROM LCSProblem WHERE Id = ?";
-
-        ArrayList<Task> tasks = new ArrayList<>();
-    
-        PreparedStatement stmt = null;
-
-        try {
-            stmt = conn.prepareStatement(sql);
-
-            stmt.setInt(1, kindId);
-  
-
-            ResultSet rs = stmt.executeQuery();
-            
-            if (rs.next()) {
-                LCSProblem prob = new LCSProblem(rs.getString(3), rs.getString(4));
-                prob.setId(kindId);
-                prob.setTitle(rs.getString(1));
-                prob.setDescription(rs.getString(2));
-                
-                return prob;
-                
-            } else {
-                throw new NonRecoverableException("Inconsisted DB LCSProb: " + kindId);
-            }
-            
-        } catch (SQLException e) {
-            throw new NonRecoverableException("CourseDAO-ERR-10" + e.toString(), e);
-        } finally {
-            close(stmt); // Don't close the connection, retrieve(courseId) will
-        }
-    }
-    
-
     
     private Timeout retrieveTimeout(int timeoutId, Connection conn) 
         throws NonRecoverableException {

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -1,0 +1,184 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.dao;
+
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.DataType;
+import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.MatrixChainProblem;
+import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
+import edu.regis.dptu.model.Task;
+import edu.regis.dptu.model.TaskKind;
+import edu.regis.dptu.svc.ProblemSvc;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+
+public class ProblemDAO extends MySqlDAO implements ProblemSvc {
+
+    /**
+     * Instantiate this Course DAO with default values.
+     */
+    public ProblemDAO() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Problem retrieve(int problemId) throws ObjNotFoundException, NonRecoverableException {
+        final String sql = "SELECT ProblemType, SubTypeId, Title, Description FROM Problem WHERE Id = ?";
+
+        Connection conn = null;
+        PreparedStatement stmt = null;
+
+        try {
+            conn = DriverManager.getConnection(URL);
+            stmt = conn.prepareStatement(sql);
+
+            stmt.setInt(1, problemId);
+
+            ResultSet rs = stmt.executeQuery();
+
+            if (rs.next()) {               
+                Problem problem = retrieveProblemSubType(problemId, 
+                                                         ProblemKind.valueOf(rs.getString(1)),
+                                                         rs.getInt(2),
+                                                         conn);
+     
+           
+                problem.setTitle(rs.getString(3));
+                problem.setDescription(rs.getString(4));              
+                
+                return problem;
+
+            } else {
+                throw new ObjNotFoundException("Course Id:" + problemId);
+            }
+        } catch (SQLException e) {
+            throw new NonRecoverableException("ProblemDAO-ERR-1" + e.toString(), e);
+        } finally {
+            close(conn, stmt);
+        }
+    }
+    
+    private void retrieveVariables(Problem problem, Connection conn) throws NonRecoverableException {
+        final String sql = "SELECT Id, VariableName, VariableValue, DataType, IsInput, Dimensions FROM Variable WHERE ProblemId = ?";
+        
+        int problemId = problem.getId();
+        
+        PreparedStatement stmt = null;
+
+        try {
+            conn = DriverManager.getConnection(URL);
+            stmt = conn.prepareStatement(sql);
+
+            stmt.setInt(1, problemId);
+            
+            ResultSet rs = stmt.executeQuery();
+            
+            while (rs.next()) {
+           //     Variable var
+                
+            //   switch (DataType.valueOf(rs.getString(4))) {
+             //      case INT:
+            //           problem.addVariable(extractIntVariable(rs));
+            //   }
+                
+            }
+            
+            
+        } catch (SQLException e) {
+            throw new NonRecoverableException("ProblemDAO-ERR-1" + e.toString(), e);
+        } finally {
+            close(stmt);
+        }
+
+    }
+    
+     private Problem retrieveProblemSubType(int id, ProblemKind type, int subTypeId,
+                                            Connection conn) throws NonRecoverableException {
+        switch (type) {
+            case LCS_PROBLEM:
+                return retrieveLCSProblem(id, subTypeId, conn);
+                
+            case MATRIX_CHAIN:
+                return null;
+                
+            case KNAPSACK_0_1:
+                return null;
+                
+            default:
+                return null;
+        }
+    }
+    
+     /**
+      * Load and return a LCSProblrem from LCSProblem table in the DB using the
+      * given subTypeId. 
+      * 
+      * 
+      * 
+      * @param id the id of the returned LCS problem
+      * @param subTypeId the id of the specific LCS problem in the LCSProblem
+      *                 table
+      * @param conn an open connection to the DB, which isn't closed.
+      * @return an LCSProblem with the given id and subTypeId
+      * @throws NonRecoverableException possible see getCause()
+      */
+    private LCSProblem retrieveLCSProblem(int id, int subTypeId, Connection conn) throws NonRecoverableException {
+         final String sql = "SELECT Sequence1,Sequence2 FROM LCSProblem WHERE Id = ?";
+
+        ArrayList<Task> tasks = new ArrayList<>();
+    
+        PreparedStatement stmt = null;
+
+        try {
+            stmt = conn.prepareStatement(sql);
+
+            stmt.setInt(1, subTypeId);
+  
+            ResultSet rs = stmt.executeQuery();
+            
+            if (rs.next()) {
+                LCSProblem prob = new LCSProblem(id, rs.getString(1), rs.getString(2));
+                prob.setSubTypeId(subTypeId);
+                prob.setTitle(rs.getString(1));
+                prob.setDescription(rs.getString(2));
+                
+                return prob;
+                
+            } else {
+                throw new NonRecoverableException("Inconsisted DB LCSProb: " + id);
+            }
+            
+        } catch (SQLException e) {
+            throw new NonRecoverableException("CourseDAO-ERR-10" + e.toString(), e);
+        } finally {
+            close(stmt); // Don't close the connection, retrieve(courseId) will
+        }
+    }
+    
+    private MatrixChainProblem retrieveMatrixProblem(int id, Connection conn) throws NonRecoverableException {
+        throw new NonRecoverableException("Matrix Chain Problem not yet implemented.");
+    }
+    
+    private MatrixChainProblem retrieveKnapsackProblem(int id, Connection conn) throws NonRecoverableException {
+        throw new NonRecoverableException("Knapsack Problem not yet implemented.");
+    }
+}

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -20,8 +20,9 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.Student;
 import edu.regis.dptu.model.Task;
 import edu.regis.dptu.model.TaskKind;
-import static edu.regis.dptu.model.TaskKind.LCS_PROBLEM;
 import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.svc.ProblemSvc;
+import edu.regis.dptu.svc.ServiceFactory;
 import edu.regis.dptu.svc.SessionSvc;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -52,7 +53,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
      */
     @Override
     public void create(TutoringSession session) throws IllegalArgException, NonRecoverableException {
-        final String sql = "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemKind, ProblemId) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?)";
+        final String sql = "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemType, ProblemId) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?)";
         
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -76,7 +77,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             stmt.setBoolean(5, session.isIsActive());
             
             Problem prob = session.getProblem();
-            stmt.setString(6, prob.getKind().toString());
+            stmt.setString(6, prob.getType().toString());
             stmt.setInt(7, prob.getId());
 
             stmt.execute();
@@ -92,7 +93,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
      */
     @Override
     public TutoringSession retrieve(Student student) throws ObjNotFoundException, NonRecoverableException {
-        final String sql = "SELECT SessionId, SecurityToken, StartDate, IsActive, ProblemKind, ProblemId FROM TutoringSession WHERE UserId = ?";
+        final String sql = "SELECT SessionId, SecurityToken, StartDate, IsActive, ProblemType, ProblemId FROM TutoringSession WHERE UserId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -118,7 +119,10 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
                 
                 TaskKind kind = TaskKind.valueOf(rs.getString(5));
                 
-                session.setProblem(retrieveProblem(kind, rs.getInt(6), conn));
+                
+                ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
+                
+                session.setProblem(problemSvc.retrieve(rs.getInt(6)));
 
                 return session;
             } else {
@@ -254,50 +258,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
         }
     }
     
-    private Problem retrieveProblem(TaskKind kind, int kindId, Connection conn) 
-        throws NonRecoverableException {
-        switch (kind) {
-            case LCS_PROBLEM:
-                return retrieveLCSProblem(kindId, conn);
-                
-            default:
-                return null;
-        }
-    }
-    
-    private LCSProblem retrieveLCSProblem(int kindId, Connection conn) throws NonRecoverableException {
-         final String sql = "SELECT Title,Description,Sequence1,Sequence2 FROM LCSProblem WHERE Id = ?";
-
-        ArrayList<Task> tasks = new ArrayList<>();
-    
-        PreparedStatement stmt = null;
-
-        try {
-            stmt = conn.prepareStatement(sql);
-
-            stmt.setInt(1, kindId);
-  
-
-            ResultSet rs = stmt.executeQuery();
-            
-            if (rs.next()) {
-                LCSProblem prob = new LCSProblem(rs.getString(3), rs.getString(4));
-                prob.setId(kindId);
-                prob.setTitle(rs.getString(1));
-                prob.setDescription(rs.getString(2));
-                
-                return prob;
-                
-            } else {
-                throw new NonRecoverableException("Inconsisted DB LCSProb: " + kindId);
-            }
-            
-        } catch (SQLException e) {
-            throw new NonRecoverableException("CourseDAO-ERR-10" + e.toString(), e);
-        } finally {
-            close(stmt); // Don't close the connection, retrieve(courseId) will
-        }
-    }
+   
 }
 
 

--- a/src/main/java/edu/regis/dptu/model/DataType.java
+++ b/src/main/java/edu/regis/dptu/model/DataType.java
@@ -1,0 +1,43 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.model;
+
+/**
+ * Known primitive data type values that can be stored as the value of a
+ * Variable within a Problem.
+ * 
+ * @author rickb
+ */
+public enum DataType {
+    BOOLEAN("boolean"),
+    
+    DOUBLE("double"),
+    
+    FLOAT("float"),
+    
+    INT("int"),
+    
+    LONG("long"),
+    
+    STRING("String");
+    
+    private String prettyName;
+    
+    private DataType(String prettyName) {
+        this.prettyName = prettyName;
+    }
+    
+    public String getPrettyName() {
+        return prettyName;
+    }
+}

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -66,15 +66,26 @@ public class LCSProblem extends Problem {
      * after all of the loops have executed.
      */
     private EXECUTION_STATE executionState;
-
-    /**
+    
+   /**
      * Initialize this problem with the given input sequences.
      *
      * @param x the first input sequence, as a String
      * @param y the second input sequence, as String
      */
     public LCSProblem(String x, String y) {
-        super();
+        this(Model.DEFAULT_ID, x, y);
+    }
+
+    /**
+     * Initialize this problem with the given input sequences.
+     *
+     * @param id, the unique id of this problem, as assigned by the DB.
+     * @param x the first input sequence, as a String
+     * @param y the second input sequence, as String
+     */
+    public LCSProblem(int id, String x, String y) {
+        super(id);
 
         this.x = x; // Store original if needed by other parts not shown
         this.y = y; // Store original if needed
@@ -105,11 +116,20 @@ public class LCSProblem extends Problem {
 
         executionState = EXECUTION_STATE.PRE;
 
-        kind = TaskKind.LCS_PROBLEM;
 
         loadCodeStatements(); // Load the pseudocode lines
 
         reset(); // Call reset to ensure consistent initial state including table values
+    }
+    
+    /**
+     * Return the type of this Dynamic Programming problem.
+     * 
+     * @return ProblemKind.LCS_PROBLEM
+     */
+    @Override
+    public ProblemKind getType() {
+        return ProblemKind.LCS_PROBLEM;
     }
 
     public EXECUTION_STATE getExecutionState() {

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -40,7 +40,7 @@ public class MatrixChainProblem extends Problem {
     
     // Stack to record changes to m[i][j] for undo functionality
     private Stack<int[]> mHistory = new Stack<>();
-
+    
     /**
      * Constructor initializes the DP variables, dimension list "d",
      * and the empty cost table "m" with -1 placeholders.
@@ -49,7 +49,19 @@ public class MatrixChainProblem extends Problem {
      * @param sizes 2D array of matrix dimensions (p x q pairs)
      */
     public MatrixChainProblem(int[][] sizes) {
-        super();
+        this(Model.DEFAULT_ID, sizes);
+    }
+
+    /**
+     * Constructor initializes the DP variables, dimension list "d",
+     * and the empty cost table "m" with -1 placeholders.
+     * Sets initial execution state and loads code statements.
+     *
+     * @param id the unique id of this problem, as assigned by the DB.
+     * @param sizes 2D array of matrix dimensions (p x q pairs)
+     */
+    public MatrixChainProblem(int id, int[][] sizes) {
+        super(id);
 
         int n = sizes.length; // number of matrices
         ArrayList<Integer> d = new ArrayList<>();
@@ -83,10 +95,19 @@ public class MatrixChainProblem extends Problem {
 
         // Set initial execution state and task kind
         executionState = EXECUTION_STATE.PRE;
-        kind = TaskKind.MATRIX_CHAIN;
 
         // Load pseudocode statements for display
         loadCodeStatements();
+    }
+    
+     /**
+     * Return the type of this Dynamic Programming problem.
+     * 
+     * @return ProblemKind.LCS_PROBLEM
+     */
+    @Override
+    public ProblemKind getType() {
+        return ProblemKind.LCS_PROBLEM;
     }
 
     /**

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -20,10 +20,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The primary Dynamic Programming task that a student is attempting to solve,
- * which is associated with a unit within a course.
+ * The Dynamic Programming problem that a student is attempting to solve.
  *
- * Subclasses need to implement the abstract loadCodeStatements
+ * The specific type of Dynamic Programming problem is specified by the
+ * value returned by the getType() method, which is declared abstract in this
+ * parent class. 
  *
  * In VanLehn's sense, this is a task for the student to complete, but we treat
  * tasks at a finer granularity i.e. as subproblems within the primary problem.
@@ -35,9 +36,19 @@ import java.util.logging.Logger;
 public abstract class Problem extends TitledModel {
 
     /**
-     * The task associated with this problem. (ToDo: )
+     * The type of this Dynamic Programming problem, which must be assigned
+     * when instantiating a subclass
      */
-    protected TaskKind kind;
+    protected ProblemKind type;
+    
+    /**
+     * The id that serves as an index into the DB subtype table. 
+     * 
+     * For example, if type is LCS_PROBLEM, then the subtype id is the id
+     * of the problem in the LCSProblem table (with the Model.id being the
+     * id in the Problem table
+     */
+    protected int subTypeId;
 
     /**
      * The variables used in the algorithmic solution to this dynamic
@@ -57,7 +68,7 @@ public abstract class Problem extends TitledModel {
      * The algorithmic solution to this dynamic programming problem as textual
      * lines of code.
      */
-    protected ArrayList codeStatements = new ArrayList();
+    protected ArrayList<String> codeStatements;
 
     /**
      * The currently line number to execute
@@ -72,14 +83,35 @@ public abstract class Problem extends TitledModel {
      */
     protected ArrayList<Integer> executionHistory;
 
+    /**
+     * Observers who are listening for changes to the state of this problem.
+     */
     protected ArrayList<ProblemListener> problemListeners;
 
+    /**
+     * Return the type of this problem.
+     * 
+     * @return 
+     */
+    public abstract ProblemKind getType();
+    
+    /**
+     * Loads the pseudo-code statements for display.
+     */
     protected abstract void loadCodeStatements();
-
+    
+    /**
+     * Instantiate a Dynamic Programming problem with a DEFAULT_ID.
+     */
     public Problem() {
         this(DEFAULT_ID);
     }
 
+    /**
+     * Instantiate a Dynamic Programming problem with the given id.
+     * 
+     * @param id unique int id of this problem, as assigned by the DB.
+     */
     public Problem(int id) {
         super(id);
 
@@ -89,12 +121,12 @@ public abstract class Problem extends TitledModel {
         problemListeners = new ArrayList<>();
     }
 
-    public TaskKind getKind() {
-        return kind;
+    public int getSubTypeId() {
+        return subTypeId;
     }
 
-    public void setKind(TaskKind kind) {
-        this.kind = kind;
+    public void setSubTypeId(int subTypeId) {
+        this.subTypeId = subTypeId;
     }
 
     public ArrayList<String> getCodeStatements() {

--- a/src/main/java/edu/regis/dptu/model/ProblemKind.java
+++ b/src/main/java/edu/regis/dptu/model/ProblemKind.java
@@ -1,0 +1,59 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.model;
+
+/**
+ * The problem types that that get be tutored to the student.
+ * 
+ * @author rickb
+ */
+public enum ProblemKind {
+    /**
+     * A Longest Common Subsequent (LCS) Dynamic Programming problem..
+     */
+    LCS_PROBLEM("Longest Commom Subsequence"),
+    
+    /**
+     * A Matrix Chaining Dynamic Programming problem
+     */
+    MATRIX_CHAIN("Matrix Chaining"),
+    
+    /**
+     * A 0-1 Knapsack Dynamic Programming problem.
+     */
+    KNAPSACK_0_1("0/1 Knapsack");
+    
+    /**
+     * A GUI displayable pretty print string identifying this problem kind.
+     */
+    private final String title;
+    
+    /**
+     * Initialize this problem kind with its title.
+     * 
+     * @param title a GUI displayable pretty print name for this problem kind.
+     */
+    ProblemKind(String title) {
+        this.title = title;
+    }
+    
+    /**
+     * Return the title for this problem kind.
+     * 
+     * @return a GUI displayable pretty print string for this problem kind
+     */
+    public String title() {
+        return title;
+    }
+}
+    

--- a/src/main/java/edu/regis/dptu/model/StepSubType.java
+++ b/src/main/java/edu/regis/dptu/model/StepSubType.java
@@ -26,6 +26,15 @@ public enum StepSubType {
      */
     INFO_MESSAGE("Information Message"),
     
+    /**
+     * The student completed a Pending Step.
+     */
+    STEP_COMPLETED("Step Comleted"),
+    
+    /**
+     * The student is being asked to review a proposed Dynamic Programming problem.
+     * 
+     */
     PROBLEM_REVIEW("Review Problem"),
     
     /**

--- a/src/main/java/edu/regis/dptu/model/Task.java
+++ b/src/main/java/edu/regis/dptu/model/Task.java
@@ -29,7 +29,7 @@ public class Task extends TitledModel {
     /**
      * Indicates the type of task the student trying to complete.
      */
-    private TaskKind kind = TaskKind.LCS_PROBLEM;
+    private TaskKind kind = TaskKind.PROBLEM;
     
     /**
      * The sequence in which this task is performed in its problem.

--- a/src/main/java/edu/regis/dptu/model/TaskKind.java
+++ b/src/main/java/edu/regis/dptu/model/TaskKind.java
@@ -19,16 +19,19 @@ package edu.regis.dptu.model;
  */
 public enum TaskKind {
     /**
-     * A task requiring a Student to complete a Problem.
+     * A task representing a top-level dynamic programming problem.
+     * (The type of the problem in the task specifies what kind of DP problem.)
      */
-    LCS_PROBLEM("LCS Problem"),
+    PROBLEM("Dynamic PRogramming Problem"),
     
-    MATRIX_CHAIN("Matrix Chaining"),
-    
-    KNAPSACK_0_1("0/1 Knapsack"),
-    
+    /**
+     * Initialize the first row of a Dynamic Programming problem table.
+     */
     INITIALIZE_FIRST_ROW("Initiailize First Row"),
     
+    /**
+     * Initialize the first column of a Dynamic Programming problem table.
+     */
     INITIALIZE_FIRST_COL("Initialize First Column"),
     
     /**

--- a/src/main/java/edu/regis/dptu/model/Variable.java
+++ b/src/main/java/edu/regis/dptu/model/Variable.java
@@ -1,0 +1,76 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.model;
+
+/**
+ *
+ * @author rickb
+ */
+public class Variable {
+    private String name;
+    
+    private DataType dataType;
+    
+    private Object value;
+    
+    private boolean isInput;
+     
+    private int dimensions;
+    
+    public Variable(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(DataType dataType) {
+        this.dataType = dataType;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public boolean isIsInput() {
+        return isInput;
+    }
+
+    public void setIsInput(boolean isInput) {
+        this.isInput = isInput;
+    }
+
+    public int getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(int dimensions) {
+        this.dimensions = dimensions;
+    }
+    
+    
+    
+}

--- a/src/main/java/edu/regis/dptu/svc/ProblemSvc.java
+++ b/src/main/java/edu/regis/dptu/svc/ProblemSvc.java
@@ -1,0 +1,37 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ * 
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ * 
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ * 
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.svc;
+
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.Problem;
+
+/**
+ * Specifies the API for Problem life-cycle maintenance (database persistence).
+ * 
+ * @author rickb
+ */
+public interface ProblemSvc {
+    /**
+     * Locate and return the Problem with the given id.
+     * 
+     * The method is similar to {@link #retrieveDigest()} except it returns
+     * the entire course content.
+     *
+     * @param problemId integer key of the Problem to load.
+     * @return The Problem with the given id.
+     * @exception ObjNotFoundException No Problem with the given id exists.
+     * @throws NonRecoverableException also see getCause().getErrorCode()..
+     */
+    Problem retrieve(int problemId) throws ObjNotFoundException, NonRecoverableException ;
+}

--- a/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
+++ b/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
@@ -14,6 +14,7 @@ package edu.regis.dptu.svc;
 
 import edu.regis.dptu.dao.AccountDAO;
 import edu.regis.dptu.dao.CourseDAO;
+import edu.regis.dptu.dao.ProblemDAO;
 import edu.regis.dptu.dao.SessionDAO;
 import edu.regis.dptu.dao.StudentModelDAO;
 
@@ -28,7 +29,7 @@ import edu.regis.dptu.dao.StudentModelDAO;
  */
 public class ServiceFactory {
     /**
-     * Return a reference to the user service.
+     * Return a reference to a User service.
      * 
      * @return AccountSvc
      */
@@ -37,12 +38,21 @@ public class ServiceFactory {
     }
     
     /**
-     * Return a reference to the course service.
+     * Return a reference to a Course service.
      * 
      * @return CourseSvc
      */
     public static CourseSvc findCourseSvc() {
         return new CourseDAO();
+    }
+    
+    /**
+     * Return a reference to a Problem service. 
+     * 
+     * @return ProblemSvc
+     */
+    public static ProblemSvc findProblemSvc() {
+        return new ProblemDAO();
     }
     
     /**

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -3,6 +3,7 @@
  */
 package edu.regis.dptu.view;
 
+import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.util.CustomProgressBar;
 import edu.regis.dptu.view.act.PracticeAction;
@@ -207,17 +208,17 @@ public class DashboardPanel extends GPanel {
      * Return the TaskKind corresponding to the currently selected problem in the dropdown.
      * @return TaskKind @author EverettCV
      */
-    public TaskKind getSelectedTaskKind() {
+    public ProblemKind getSelectedProblemKind() {
         int index = problemSelector.getSelectedIndex();
         switch (index) {
             case 0:
-                return TaskKind.LCS_PROBLEM;
+                return ProblemKind.LCS_PROBLEM;
             case 1:
-                return TaskKind.MATRIX_CHAIN;
+                return ProblemKind.MATRIX_CHAIN;
             case 2:
-                return TaskKind.KNAPSACK_0_1;
+                return ProblemKind.KNAPSACK_0_1;
             default:
-                return TaskKind.LCS_PROBLEM; // Fallback
+                return ProblemKind.LCS_PROBLEM; // Fallback
         }
     }
 }

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import javax.swing.JPanel;
 import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
 
 /**
  * Displays the appropriate input view depending on the selected problem type.
@@ -36,9 +37,9 @@ public class ProblemInputView extends JPanel {
         }
 
         // Otherwise, dynamically load the correct input view based on the Problem's TaskKind
-        TaskKind kind = problem.getKind();
+        ProblemKind type = problem.getType();
 
-        switch (kind) {
+        switch (type) {
             case LCS_PROBLEM:
                 LCSInputView lcsInputView = new LCSInputView(parentView);
                 add(lcsInputView, BorderLayout.CENTER);

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -20,6 +20,7 @@ import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.MatrixChainProblem;
 // Import Knapsack problem once implemented and update the switch statement below.
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 import javax.swing.JButton;
@@ -326,15 +327,17 @@ public class SplashFrame extends JFrame {
      * Select the lesson screen for the given problem type (TaskKind). 
      * Creates a new TutoringSession with the appropriate Problem. @author EverettCV
      */
-    public void selectLessonScreen(TaskKind kind) {
+    public void selectLessonScreen(ProblemKind kind) {
 
         // Step 1: Create the correct Problem subclass based on TaskKind
         Problem problem;
 
         switch (kind) {
             case LCS_PROBLEM:
+                // ToDO, this should be obtained from the Task
                 problem = new LCSProblem("skullandbones", "lullabybabies");
                 break;
+           /*
             case MATRIX_CHAIN:
                 problem = new MatrixChainProblem(new int[][]{
                     {10, 20},
@@ -347,6 +350,7 @@ public class SplashFrame extends JFrame {
                 System.out.println("KnapsackProblem not yet implemented. Defaulting to LCSProblem");
                 problem = new LCSProblem("skullandbones", "lullabybabies");
                 break;
+*/
             default:
                 // Fallback to LCS if somehow another TaskKind got through
                 problem = new LCSProblem("skullandbones", "skullandbones");

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -14,6 +14,7 @@ package edu.regis.dptu.view;
 
 import edu.regis.dptu.model.LCSProblem; // Needed for creating the initial problem
 import edu.regis.dptu.model.Problem;   // Needed for type consistency
+import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.model.TutoringSession;
 
@@ -200,10 +201,10 @@ public class TutoringSessionView extends GPanel {
             (currentProblem != null ? Integer.toHexString(currentProblem.hashCode()) : "null"));
 
         // Update views depending on Problem type
-        TaskKind kind = currentProblem.getKind();
-        System.out.println("DEBUG: TaskKind is " + kind);
+        ProblemKind type = currentProblem.getType();
+        System.out.println("DEBUG: TaskKind is " + type);
 
-        switch (kind) {
+        switch (type) {
             case LCS_PROBLEM:
                 System.out.println("DEBUG: LCSProblem detected. Passing model to views.");
 

--- a/src/main/java/edu/regis/dptu/view/act/TeachMeAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachMeAction.java
@@ -12,6 +12,7 @@
  */
 package edu.regis.dptu.view.act;
 
+import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.view.MainFrame;
 import edu.regis.dptu.view.SplashFrame;
@@ -51,12 +52,12 @@ public class TeachMeAction extends DpTuGuiAction {
 
         if (dashboard == null) {
             System.err.println("DashboardPanel not initialized. Defaulting to LCS_PROBLEM.");
-            SplashFrame.instance().selectLessonScreen(TaskKind.LCS_PROBLEM);
+            SplashFrame.instance().selectLessonScreen(ProblemKind.LCS_PROBLEM);
             return;
         }
 
         // Get the selected TaskKind from the DashboardPanel
-        TaskKind selectedKind = dashboard.getSelectedTaskKind();
+        ProblemKind selectedKind = dashboard.getSelectedProblemKind();
         System.out.println("TeachMeAction selected TaskKind: " + selectedKind);
 
         // Call SplashFrame to transition to the lesson screen with this TaskKind


### PR DESCRIPTION
The development code had compilation errors in ProblemDAO. 
This code didn't appear to be fully fleshed out. 
Updated the DB to reflect the fact that various types of subproblems can be created.
Changed the corresponding code to load the proper problem subtype (only for LCS Problems,
Matrix Chain and Knapsack will still need to be done.)
Testing: I dropped the DB, recreated it. Hence, created a new Account.
The account created and a subsequent sign in worked with being able to go to the Do One practice screen.
A tutoring session was created in the db, but no associated PendingTask or PendingStep. 