### PR TITLE
DPTU-55 add StudentModel creation during Account creation

### DIFF
--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -45,6 +45,11 @@ CREATE TABLE Account (
    PRIMARY KEY (UserId)
 );
 
+CREATE TABLE StudentModel (
+   UserId VARCHAR(255) NOT NULL PRIMARY KEY,
+   ScaffoldLevel VARCHAR(16) NOT NULL
+);
+
 #
 # Course related Tables
 

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -429,17 +429,15 @@ public class DpTuTutor implements TutorSvc {
         student = new Student(account);
         studentModel = student.getStudentModel();
 
-        // ToDo: follow ShaTu to create these 
-        //for (KnowledgeComponent outcome : course.getOutcomes()) {
-        //    Assessment assessment = new Assessment(outcome, AssessmentLevel.NOT_STARTED);
+        for (KnowledgeComponent outcome : course.getOutcomes()) {
+            Assessment assessment = new Assessment(outcome, AssessmentLevel.NOT_STARTED);
 
-         //   studentModel.addAssessment(outcome.getId(), assessment);
-        //}
+            studentModel.addAssessment(outcome.getId(), assessment);
+        }
 
-        // ToDo: Add the Student model service and associated DAO
-        //StudentModelSvc stuSvc = ServiceFactory.findStudentModelSvc();
+        StudentModelSvc stuSvc = ServiceFactory.findStudentModelSvc();
 
-       // stuSvc.create(student);
+        stuSvc.create(student);
 
         return student;
 


### PR DESCRIPTION
During account creation, the StudentModel was not being created in the DB.
The StudentModel table was non-existent and was added. The tutor was updated to populate this table, along with assessments for course KnowledgeComponents for the signed-in student user. 
