### PR TITLE
Refactor TutoringSessionView and children views

### DIFF
--- a/src/main/java/edu/regis/dptu/view/CodeView.java
+++ b/src/main/java/edu/regis/dptu/view/CodeView.java
@@ -39,15 +39,12 @@ public class CodeView extends GPanel implements ProblemListener {
 
     private ArrayList<String> statementStrings;
     private ArrayList<JLabel> statementJLabels;
-    private SubproblemTableView table; // Keep if needed for other interactions
 
     /** Used as a background color */
     private static final Color MEDIUM_GRAY = new Color(215, 215, 215);
 
     /** Initialize this view including creating and laying out its child components. */
     public CodeView(SubproblemTableView table) {
-        this.table = table; // Store reference if needed
-
         // Initialize label list
         statementJLabels = new ArrayList<>();
 
@@ -73,12 +70,7 @@ public class CodeView extends GPanel implements ProblemListener {
      * @param model a CodeModel.
      */
     public void setModel(Problem model) {
-        // NOTE: Cannot remove listener from the old model as 'removeProblemListener'
-        //       method doesn't seem to exist on the Problem interface/class.
-        // if (this.model != null) {
-        //    this.model.removeProblemListener(this); // This line caused compilation error
-        // }
-
+        // NOTE: Cannot remove listener from the old model
         this.model = model;
 
         // Clear previous UI components
@@ -94,6 +86,10 @@ public class CodeView extends GPanel implements ProblemListener {
             // if the same listener is added multiple times if setModel is called repeatedly
             // with the same model instance (which shouldn't typically happen).
             this.model.addProblemListener(this);
+
+            setVisible(true);
+        } else {
+            setVisible(false);
         }
 
         // Update the view to reflect the initial state of the new model

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -30,9 +30,6 @@ import javax.swing.SpinnerNumberModel;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
-// import javax.swing.event.ChangeEvent; // Not used in old code
-// import javax.swing.event.ChangeListener; // Not used in old code
-
 /**
  * A panel containing buttons and controls that allow a user to step forward and backward through
  * the LCS algorithm execution.
@@ -98,12 +95,6 @@ public class StepViewPanel extends GPanel implements ProblemListener {
      * @param model a Problem model
      */
     public void setModel(Problem model) {
-        // NOTE: Cannot remove listener from the old model as 'removeProblemListener'
-        //       method doesn't seem to exist on the Problem interface/class.
-        // if (this.model != null) {
-        //    this.model.removeProblemListener(this); // This line caused compilation error
-        // }
-
         this.model = model;
 
         // Add this view as a listener to the new model
@@ -112,6 +103,10 @@ public class StepViewPanel extends GPanel implements ProblemListener {
             // if the same listener is added multiple times if setModel is called repeatedly
             // with the same model instance.
             this.model.addProblemListener(this);
+
+            setVisible(true);
+        } else {
+            setVisible(false);
         }
 
         updateView(); // Update button states based on the new model

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -121,9 +121,7 @@ public class SubSequenceView extends JPanel {
     public void setModel(Problem currentProblem) {
         if (currentProblem != null && currentProblem instanceof LCSProblem) {
             this.updateWords(
-                ((LCSProblem) currentProblem).getX(),
-                ((LCSProblem) currentProblem).getY()
-            );
+                    ((LCSProblem) currentProblem).getX(), ((LCSProblem) currentProblem).getY());
 
             setVisible(true);
         } else if (currentProblem == null) {

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -23,6 +23,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
+import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.Problem;
+
 /**
  * This is the Subsequence view for the TutoringSession View. The title, words, and button are
  * displayed. Both words entered to find LCS are shown with the length of each. When the button is
@@ -113,6 +116,19 @@ public class SubSequenceView extends JPanel {
     // Button trigger
     private void stepThroughLCS() {
         canvas.highlightLCS();
+    }
+
+    public void setModel(Problem currentProblem) {
+        if (currentProblem != null && currentProblem instanceof LCSProblem) {
+            this.updateWords(
+                ((LCSProblem) currentProblem).getX(),
+                ((LCSProblem) currentProblem).getY()
+            );
+
+            setVisible(true);
+        } else if (currentProblem == null) {
+            setVisible(false);
+        }
     }
 
     /**

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -91,8 +91,12 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     public void setModel(Problem model) {
         this.model = model;
         if (this.model != null) {
-            this.model.addProblemListener(this); // Listen for updates
-            updateView(); // Initial view update
+            this.model.addProblemListener(this);
+            updateView();
+
+            setVisible(true);
+        } else {
+            setVisible(false);
         }
     }
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -18,7 +18,6 @@ import javax.swing.JLabel;
 
 import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
-import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.TutoringSession;
 
 /**
@@ -28,12 +27,9 @@ import edu.regis.dptu.model.TutoringSession;
  * @author rickb (Modified by Assistant for Functional Integration & Debug)
  */
 public class TutoringSessionView extends GPanel {
-
-    // ... (fields remain the same) ...
     private TutoringSession model;
     private VariablesView variablesView;
     private JLabel subproblemView;
-    private JLabel xView;
     private CodeView codeView;
 
     private ProblemInputView problemInputView;
@@ -123,8 +119,7 @@ public class TutoringSessionView extends GPanel {
     private void initializeComponents() {
         System.out.println("DEBUG: TutoringSessionView initializing components...");
         variablesView = new VariablesView();
-        subproblemView = new JLabel("Subproblem View"); // Original Placeholder
-        xView = new JLabel("X View"); // Original Placeholder
+        subproblemView = new JLabel("Subproblem View");
 
         problemInputView = new ProblemInputView(this);
 
@@ -283,93 +278,9 @@ public class TutoringSessionView extends GPanel {
 
     }
 
-    /**
-     * Display the current model in our child components. **FUNCTIONAL CHANGE:** Ensures all views
-     * needing the model receive it.
-     */
-    private void updateView() {
+    private void updateView(Problem currentProblem) {
         System.out.println("DEBUG: TutoringSessionView.updateView called.");
 
-        if (model == null) {
-            System.out.println(
-                    "DEBUG: TutoringSessionView.updateView: Main session model is null. Setting child models to null.");
-            // Set models to null if session model is null
-            stepViewPanel.setModel(null);
-            codeView.setModel(null);
-            variablesView.setModel(null);
-            tableView.setModel(null);
-            return;
-        }
-
-        Problem currentProblem = model.getProblem();
-        System.out.println(
-                "DEBUG: TutoringSessionView.updateView: Current problem from session: "
-                        + (currentProblem != null
-                                ? Integer.toHexString(currentProblem.hashCode())
-                                : "null"));
-
-        // Update views depending on Problem type
-        ProblemKind type = currentProblem.getType();
-        System.out.println("DEBUG: TaskKind is " + type);
-
-        switch (type) {
-            case LCS_PROBLEM:
-                System.out.println("DEBUG: LCSProblem detected. Passing model to views.");
-
-                // Pass the current problem to all relevant LCS views
-                stepViewPanel.setModel(currentProblem);
-                codeView.setModel(currentProblem);
-                variablesView.setModel(currentProblem);
-                tableView.setModel(currentProblem);
-
-                // Subsequence View - update and show
-                subSeqView.updateWords(
-                        ((LCSProblem) currentProblem).getX(), ((LCSProblem) currentProblem).getY());
-                subSeqView.setVisible(true);
-
-                // Make sure all views are visible
-                stepViewPanel.setVisible(true);
-                codeView.setVisible(true);
-                variablesView.setVisible(true);
-                tableView.setVisible(true);
-
-                break;
-
-            case MATRIX_CHAIN:
-                System.out.println("DEBUG: MatrixChainProblem detected. Clearing LCS views.");
-
-                // LCS views should not display anything for Matrix problems
-                stepViewPanel.setModel(null);
-                codeView.setModel(null);
-                variablesView.setModel(null);
-                tableView.setModel(null);
-
-                stepViewPanel.setVisible(false);
-                codeView.setVisible(false);
-                variablesView.setVisible(false);
-                tableView.setVisible(false);
-                subSeqView.setVisible(false); // Hide Subsequence view too
-
-                // TODO: Eventually create Matrix-specific step/code/table views,
-                // you can add logic here to pass the currentProblem to those views
-                break;
-
-            default:
-                System.out.println("DEBUG: Unrecognized TaskKind. Clearing views.");
-                stepViewPanel.setModel(null);
-                codeView.setModel(null);
-                variablesView.setModel(null);
-                tableView.setModel(null);
-
-                stepViewPanel.setVisible(false);
-                codeView.setVisible(false);
-                variablesView.setVisible(false);
-                tableView.setVisible(false);
-                subSeqView.setVisible(false);
-                break;
-        }
-
-        // Rebuild the correct ProblemInputView
         if (problemInputView != null) {
             remove(problemInputView);
         }
@@ -390,13 +301,22 @@ public class TutoringSessionView extends GPanel {
                 5,
                 5);
 
-        // Refresh layout after potentially changing models
         revalidate();
         repaint();
     }
 
     void setModel(TutoringSession model) {
         this.model = model;
-        updateView();
+
+        Problem currentProblem = null;
+        if (model != null) currentProblem = model.getProblem();
+
+        subSeqView.setModel(currentProblem);
+        stepViewPanel.setModel(currentProblem);
+        codeView.setModel(currentProblem);
+        variablesView.setModel(currentProblem);
+        tableView.setModel(currentProblem); 
+
+        updateView(currentProblem);
     }
 }

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -315,7 +315,7 @@ public class TutoringSessionView extends GPanel {
         stepViewPanel.setModel(currentProblem);
         codeView.setModel(currentProblem);
         variablesView.setModel(currentProblem);
-        tableView.setModel(currentProblem); 
+        tableView.setModel(currentProblem);
 
         updateView(currentProblem);
     }

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -32,11 +32,11 @@ public class VariablesView extends GPanel {
 
     public void setModel(Problem model) {
         this.model = model;
-        
+
         if (model != null) {
-                setVisible(true);
+            setVisible(true);
         } else {
-                setVisible(false);
+            setVisible(false);
         }
 
         updateView();

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -32,6 +32,13 @@ public class VariablesView extends GPanel {
 
     public void setModel(Problem model) {
         this.model = model;
+        
+        if (model != null) {
+                setVisible(true);
+        } else {
+                setVisible(false);
+        }
+
         updateView();
     }
 


### PR DESCRIPTION
## Ticket

[TutoringSessionView updateView](https://dptuapp.atlassian.net/browse/DPTU-57)

## Changes

- TutoringSessionView
  - removed the unnecessary switch statement
  - removed unnecessary if statements (the children views were set with the problem if it was null or not)
- Children views
  - became responsible for when they became visible themselves (when the current problem was not null)

## Justification

Cleaned up the code for better readability and maintainability 

## Screenshot

Functionality remains the same
<img width="1818" height="971" alt="Screenshot 2025-09-21 162319" src="https://github.com/user-attachments/assets/c735aeee-8ee5-48b9-a922-21c60242c497" />
