### PR TITLE
DPTU-59 SubproblemTableView

### DIFF
--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -106,11 +106,11 @@ public class MatrixChainProblem extends Problem {
     /**
      * Return the type of this Dynamic Programming problem.
      *
-     * @return ProblemKind.LCS_PROBLEM
+     * @return ProblemKind.MATRIX_CHAIN
      */
     @Override
     public ProblemKind getType() {
-        return ProblemKind.LCS_PROBLEM;
+        return ProblemKind.MATRIX_CHAIN;
     }
 
     /**

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -91,9 +91,9 @@ public class LCSInputView extends JPanel {
         System.out.println("Submitted String 1: " + string1);
         System.out.println("Submitted String 2: " + string2);
 
-        //LCSProblem newProblem = new LCSProblem(string1, string2);
-        //parentView.getTableView().setModel(newProblem);
-        //parentView.getSubSeqView().updateWords(string1, string2);
+        // LCSProblem newProblem = new LCSProblem(string1, string2);
+        // parentView.getTableView().setModel(newProblem);
+        // parentView.getSubSeqView().updateWords(string1, string2);
 
         Container tempView = this.getParent().getParent();
         // For now, use getParent().getParent() to find TutoringSessionView instance
@@ -105,7 +105,7 @@ public class LCSInputView extends JPanel {
                 LCSProblem newProblem = new LCSProblem(string1, string2);
                 grandparentView.getTableView().setModel(newProblem);
                 grandparentView.getSubSeqView().setModel(newProblem);
-                //grandparentView.getSubSeqView().updateWords(string1, string2);
+                // grandparentView.getSubSeqView().updateWords(string1, string2);
             } else {
                 System.out.println(
                         "getParent().getParent() did not lead to " + "TutoringSessionView");

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -103,7 +103,8 @@ public class LCSInputView extends JPanel {
                 grandparentView.getSubSeqView().setModel(newProblem);
             } else {
                 System.out.println(
-                        "LCSInputView: getParent().getParent() did not lead to " + "TutoringSessionView");
+                        "LCSInputView: getParent().getParent() did not lead to "
+                                + "TutoringSessionView");
             }
         } catch (NullPointerException e) {
             System.out.println(e);

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -11,6 +11,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
+import edu.regis.dptu.model.LCSProblem;
+
 /**
  * LCSInputView provides two input fields and a submit button for entering strings in the LCS
  * tutoring problem.
@@ -89,11 +91,10 @@ public class LCSInputView extends JPanel {
         System.out.println("Submitted String 1: " + string1);
         System.out.println("Submitted String 2: " + string2);
 
+        LCSProblem newProblem = new LCSProblem(string1, string2);
+        parentView.getTableView().setModel(newProblem);
         parentView.getSubSeqView().updateWords(string1, string2);
-        parentView.getTableView().updateStrings(string1, string2);
-
-        // TODO: Future: Also update LCSProblem model instance
-        //       so that step-by-step execution uses the new user input.
+        
         // TODO: Add input validation (e.g., prevent empty submissions).
     }
 

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -91,10 +91,6 @@ public class LCSInputView extends JPanel {
         System.out.println("Submitted String 1: " + string1);
         System.out.println("Submitted String 2: " + string2);
 
-        //LCSProblem newProblem = new LCSProblem(string1, string2);
-        //parentView.getTableView().setModel(newProblem);
-        //parentView.getSubSeqView().updateWords(string1, string2);
-
         Container tempView = this.getParent().getParent();
         // For now, use getParent().getParent() to find TutoringSessionView instance
         // This code is fragile, if you've changed the component heirarchy you
@@ -105,17 +101,13 @@ public class LCSInputView extends JPanel {
                 LCSProblem newProblem = new LCSProblem(string1, string2);
                 grandparentView.getTableView().setModel(newProblem);
                 grandparentView.getSubSeqView().setModel(newProblem);
-                //grandparentView.getSubSeqView().updateWords(string1, string2);
             } else {
                 System.out.println(
-                        "getParent().getParent() did not lead to " + "TutoringSessionView");
+                        "LCSInputView: getParent().getParent() did not lead to " + "TutoringSessionView");
             }
         } catch (NullPointerException e) {
             System.out.println(e);
         }
-
-        //        parentView.getSubSeqView().updateWords(string1, string2);
-        //        parentView.getTableView().updateStrings(string1, string2);
 
         // TODO: Add input validation (e.g., prevent empty submissions).
     }

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -94,7 +94,7 @@ public class LCSInputView extends JPanel {
         LCSProblem newProblem = new LCSProblem(string1, string2);
         parentView.getTableView().setModel(newProblem);
         parentView.getSubSeqView().updateWords(string1, string2);
-        
+
         // TODO: Add input validation (e.g., prevent empty submissions).
     }
 

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -125,16 +125,17 @@ class SubSequenceView extends JPanel implements ProblemListener {
         canvas.highlightLCS();
     }
 
-//    public void setModel(Problem currentProblem) {
-//        if (currentProblem != null && currentProblem instanceof LCSProblem) {
-//            this.updateWords(
-//                    ((LCSProblem) currentProblem).getX(), ((LCSProblem) currentProblem).getY());
-//
-//            setVisible(true);
-//        } else if (currentProblem == null) {
-//            setVisible(false);
-//        }
-//    }
+    //    public void setModel(Problem currentProblem) {
+    //        if (currentProblem != null && currentProblem instanceof LCSProblem) {
+    //            this.updateWords(
+    //                    ((LCSProblem) currentProblem).getX(), ((LCSProblem)
+    // currentProblem).getY());
+    //
+    //            setVisible(true);
+    //        } else if (currentProblem == null) {
+    //            setVisible(false);
+    //        }
+    //    }
 
     /**
      * Updates the displayed input strings and lengths when new inputs are submitted.

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -35,7 +35,9 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
@@ -92,6 +94,20 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         this.model = model;
         if (this.model != null) {
             this.model.addProblemListener(this);
+            //When the Problem changes, we should updateStrings() to match
+            ProblemKind pKind = model.getType();
+            switch(pKind) {
+                case MATRIX_CHAIN:
+                    //TODO
+                    break;
+                case KNAPSACK_0_1:
+                    //TODO
+                    break;
+                default: //i.e. LCS_PROBLEM
+                    String s1 = ((LCSProblem)model).getX();
+                    String s2 = ((LCSProblem)model).getY();
+                    updateStrings(s1, s2);
+            }
             updateView();
 
             setVisible(true);
@@ -199,7 +215,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             columnModel.getColumn(0).setPreferredWidth(150);
         }
         // Set header height
-        table.getTableHeader().setPreferredSize(new Dimension(25, 25));
+        table.getTableHeader().setPreferredSize(new Dimension(25, 45));
 
         // Wrap table in scroll pane for overflow
         sp = new JScrollPane(table);
@@ -263,15 +279,6 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 toadd[0] = rowHeaders.get(i) + "  (" + (i - 1) + ")";
             } else {
                 toadd[0] = rowHeaders.get(i);
-            }
-            toadd[1] = 0; // Base case column value
-            // Fill remaining cells with default: empty for data rows, zero for header row
-            for (int p = 2; p < toadd.length; p++) {
-                if (i == 0) {
-                    toadd[p] = 0;
-                } else {
-                    toadd[p] = "";
-                }
             }
             rows.add(toadd);
         }

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -94,18 +94,18 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         this.model = model;
         if (this.model != null) {
             this.model.addProblemListener(this);
-            //When the Problem changes, we should updateStrings() to match
+            // When the Problem changes, we should updateStrings() to match
             ProblemKind pKind = model.getType();
-            switch(pKind) {
+            switch (pKind) {
                 case MATRIX_CHAIN:
-                    //TODO
+                    // TODO
                     break;
                 case KNAPSACK_0_1:
-                    //TODO
+                    // TODO
                     break;
-                default: //i.e. LCS_PROBLEM
-                    String s1 = ((LCSProblem)model).getX();
-                    String s2 = ((LCSProblem)model).getY();
+                default: // i.e. LCS_PROBLEM
+                    String s1 = ((LCSProblem) model).getX();
+                    String s2 = ((LCSProblem) model).getY();
                     updateStrings(s1, s2);
             }
             updateView();


### PR DESCRIPTION
Fixed copy-paste error in MatrixChainProblem.java

LCSInputView.java 
I invoked SubproblemTableView’s setModel() instead of updateStrings()
(setModel() now calls updateStrings() internally, making the call to updateStrings in LCSInputView unnecessary)
Also incorporated Harrison's newly written SubSequenceView.setModel() instead of the updateWords() method from before.

SubproblemTableView.java
-I changed the height of the header so everything fits
-I removed code in buildTableData() that caused the table to be prefilled with zeroes in row -1 and column -1 whenever the table changes. This was incorrect behavior and with my changes, it gets rewritten immediately by a blank table anyway.
-In setModel(), I added a call to updateStrings() whenever the problem changes. I used a switch statement to only call updateStrings for an LCSProblem - the others will have to wait until those problem types are implemented (I'm not sure what they would need).

I should mention, the big problem I was having with the table was that when you changed the strings via the textboxes at the top of the screen, the updateStrings() method would redraw the table, plus update the subsequence view. But if you closed the window and then reopened it, the screen would be in an inconsistent state - the table would still have the newly entered strings, but the subsequence view would revert to the old problem. Invisibly, the CodeView, VariablesView, StepView, SubsequenceView and SubproblemTableView all still had their Problem instance set to the original strings "skullandbones" and "lullabybabies". With my changes, the table's visual appearance and Problem instance always match, and when you close the window and reopen it, it reverts to the original problem and can still be stepped through.

I did not do anything to problemUpdated().