### PR TITLE
DPTU-65 Remove redundant constructor call

### DIFF
--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -322,9 +322,7 @@ public class SplashFrame extends JFrame {
         if (this.tutoringSession == null) {
             this.tutoringSession = new TutoringSession(getAccount(), problem);
         } else {
-            // Reuse the account, but replace the problem
-            this.tutoringSession =
-                    new TutoringSession(this.tutoringSession.getStudent().getAccount(), problem);
+            this.tutoringSession.setProblem(problem);
         }
 
         // Pass the new session to the MainFrame


### PR DESCRIPTION
In SplashFrame.java, I removed a constructor call for a TutoringSession object and replaced it with a call to setProblem() instead. 
It gets called when you click "teach me"