### PR TITLE
DPTU-69 Remove parameters from views

### DIFF
--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -47,8 +47,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
     public SubSequenceCanvasView canvas;
     private Problem model;
 
-    public SubSequenceView(String word1, String word2) {
-        initializeComponents(word1, word2);
+    public SubSequenceView() {
+        initializeComponents();
         layoutComponents();
 
         setPreferredSize(new Dimension(600, 300));
@@ -60,26 +60,26 @@ class SubSequenceView extends JPanel implements ProblemListener {
      * @param word1
      * @param word2
      */
-    public void initializeComponents(String word1, String word2) {
+    private void initializeComponents() {
         titleLabel = new JLabel("Subsequence Highlighter");
         titleLabel.setForeground(Color.BLACK);
         titleLabel.setFont(new Font("Segoe UI", Font.BOLD, 18));
         titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
-        lengthLabel1 = new JLabel("x=" + word1.length());
+        lengthLabel1 = new JLabel("x=");
         lengthLabel1.setFont(new Font("Arial", Font.PLAIN, 16));
 
-        lengthLabel2 = new JLabel("y=" + word2.length());
+        lengthLabel2 = new JLabel("y=");
         lengthLabel2.setFont(new Font("Arial", Font.PLAIN, 16));
 
         stepButton = new JButton("Step LCS");
         stepButton.addActionListener(e -> stepThroughLCS());
 
-        canvas = new SubSequenceCanvasView(word1, word2);
+        canvas = new SubSequenceCanvasView("word1", "word2");
     }
 
     /** The components of the view are displayed in specific positions. */
-    public void layoutComponents() {
+    private void layoutComponents() {
         setLayout(new BorderLayout());
 
         // Display 'Subsequence Highlighter'
@@ -93,14 +93,14 @@ class SubSequenceView extends JPanel implements ProblemListener {
         // originally, but updates the line1 appropriately when inputs change.
         JPanel line1 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line1.add(lengthLabel1);
-        wordLabel1 = new JLabel(canvas.getWord1());
+        wordLabel1 = new JLabel();
         line1.add(wordLabel1);
 
         // Changed (April 17, 2025 - EverettCV): Now loads default value of the second variable
         // originally, but updates the line2 appropriately when inputs change.
         JPanel line2 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line2.add(lengthLabel2);
-        wordLabel2 = new JLabel(canvas.getWord2());
+        wordLabel2 = new JLabel();
         line2.add(wordLabel2);
 
         wordPanel.add(line1);
@@ -152,7 +152,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
     public void updateWords(String word1, String word2) {
         // Update lengths
         lengthLabel1.setText("x=" + word1.length());
-        lengthLabel2.setText("x=" + word2.length());
+        lengthLabel2.setText("y=" + word2.length());
 
         wordLabel1.setText(word1);
         wordLabel2.setText(word2);

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -62,14 +62,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
      * @param string1 X-axis labels (to build rows)
      * @param string2 Y-axis labels (to build columns)
      */
-    public SubproblemTableView(String string1, String string2) {
-        // Convert inputs to uppercase for consistent labeling
-        string1 = string1.toUpperCase();
-        string2 = string2.toUpperCase();
-
-        // Build headers and data arrays based on inputs
-        buildColumnHeaders(string2);
-        buildTableData(string1);
+    public SubproblemTableView() {
 
         // Initialize Swing components and layout
         initializeComponents();

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -16,7 +16,6 @@ import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
 
-import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.TutoringSession;
 
@@ -122,7 +121,7 @@ public class TutoringSessionView extends GPanel {
         subproblemView = new JLabel("Subproblem View");
 
         problemInputView = new ProblemInputView();
-        
+
         subSeqView = new SubSequenceView(); // Original init
         tableView = new SubproblemTableView();
         codeView = new CodeView(tableView); // Original init

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -122,35 +122,11 @@ public class TutoringSessionView extends GPanel {
         subproblemView = new JLabel("Subproblem View");
 
         problemInputView = new ProblemInputView();
-
-        String initialX = "skullandbones";
-        String initialY = "lullabybabies";
-        subSeqView = new SubSequenceView(initialX, initialY); // Original init
-        tableView = new SubproblemTableView(initialX, initialY);
+        
+        subSeqView = new SubSequenceView(); // Original init
+        tableView = new SubproblemTableView();
         codeView = new CodeView(tableView); // Original init
-
-        // *** Create the single, shared Problem instance ***
-        Problem sharedProblem = new LCSProblem(initialX, initialY);
-        System.out.println(
-                "DEBUG: TutoringSessionView created sharedProblem: "
-                        + Integer.toHexString(sharedProblem.hashCode()));
-
-        // *** Initialize StepViewPanel with the shared Problem ***
-        stepViewPanel = new StepViewPanel(sharedProblem);
-
-        // *** Set the shared Problem model on other views ***
-        System.out.println("DEBUG: TutoringSessionView setting model on CodeView...");
-        codeView.setModel(sharedProblem);
-        System.out.println("DEBUG: TutoringSessionView setting model on VariablesView...");
-        variablesView.setModel(sharedProblem);
-        System.out.println("DEBUG: TutoringSessionView setting model on SubproblemTableView...");
-        // *** Set model on tableView - This now handles listener registration ***
-        tableView.setModel(sharedProblem);
-
-        // *** Listener addition REMOVED/COMMENTED OUT here ***
-        // if (sharedProblem != null) {
-        //    sharedProblem.addProblemListener(tableView); // Now handled by tableView.setModel()
-        // }
+        stepViewPanel = new StepViewPanel();
 
         // We'll add these components later
         // stepCompletionView = new StepCompletionView();


### PR DESCRIPTION
- ### TutoringSessionView
Under initializeComponents() I removed the hard-coded strings and accompanying Problem instance with all the setModel() calls - these values were being overwritten by SplashFrame's selectLessonScreen() before the main frame was shown to the user anyway.
- ### SubproblemTableView and SubSequenceView
Removed the need for parameters in the constructors. These now depend on the setModel() method being called before they can display a problem. Before, you could have called the constructors and had the view display properly with no Problem model having been set (where would we get strings from if the model hasn't been decided on yet?).
- ### SubSequenceCanvasView
This requires two strings in the constructor. I didn't change it because removing them caused a null pointer exception. The reason why is that every time you reset one of the strings, it calls the findLCS() method again. So when SubSequenceView calls 
canvas.setWord1(word1);
you wind up getting a null pointer exception because word 2 hasn't been set yet (it will be on the next line). The only way to fix this is to remove the call to findLCS() from the setWord() methods and then call it separately afterwards, but that would require making it public so it can be accessed from SubSequenceView. I'm open to opinions on this matter.