### PR TITLE
Fix seed step unit id in seed

### DIFF
--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -281,7 +281,7 @@ INSERT INTO Step
   StepSubType,
   SubTypeId, TimeoutId)
  VALUES
- (0, 1, 0, 0, 0,
+ (0, 1, 1, 0, 0,
   'Review Problem', 'Acknowledge understanding of the dynamic programming problem.',
   0, 'PROBLEM_REVIEW', 0, 0);
 


### PR DESCRIPTION
The '0' unit id does not exist, so when adding this seed data, it fails. 