### PR TITLE
Dptu 76 - Add Logging Dependencies and Base SLF4J/Log4j2 Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .DS_Store
 nbproject/
 src/main/java/resources/Data/
+.vscode/settings.json

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <exec.mainClass>edu.regis.dptuapp.DpTuApp</exec.mainClass>
+        <exec.mainClass>edu.regis.dptu.DpTuApp</exec.mainClass>
     </properties>
         <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -114,5 +114,45 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Start Logging Dependencies -->
+        <!-- SLF4J API, Abstracts Chosen Logging Engine -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.16</version>
+        </dependency>
+
+        <!-- Log4j2 Core + API, Our Logging Engine -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.23.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.23.1</version>
+        </dependency>
+
+        <!-- SLF4J > Log4j2 Binding (routes SLF4J calls to Log4j2) -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.23.1</version>
+        </dependency>
+
+        <!-- I'm going to keep this commented until we implement it. -->
+        <!-- Route java.util.logging (JUL) to Log4j2 -->
+        <!-- To activate, run with: -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -->
+        <!--
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+            <version>2.23.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        -->
+
+
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>edu.regis.dptu.DpTuApp</exec.mainClass>
     </properties>
-        <repositories>
+    <repositories>
         <repository>
           <id>CronApp</id>
           <name>CronApp Repository</name>
@@ -20,11 +20,11 @@
     </repositories>
     <build>
         <resources>
-        <resource>
-            <directory>
-                src/main/java/resources
-            </directory>
-        </resource>
+            <resource>
+                <directory>
+                    src/main/java/resources
+                </directory>
+            </resource>
         </resources>
     
         <plugins>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>2.0.9</version> <!-- Use the latest version available -->
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,33 @@
+<Configuration status="WARN">
+
+  <Properties>
+    <Property name="APP_NAME">dptu</Property>
+    <Property name="LOG_DIR">${sys:user.home}/.${APP_NAME}/logs</Property>
+    <Property name="ROOT_LEVEL">${sys:LOG_LEVEL:-INFO}</Property>
+  </Properties>
+
+  <Appenders>
+    <Console name="Console">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5p [%t] %c{1.} - %m%n"/>
+    </Console>
+
+    <RollingFile name="File"
+      fileName="${LOG_DIR}/${APP_NAME}.log"
+      filePattern="${LOG_DIR}/archive/${APP_NAME}-%d{yyyy-MM-dd}-%i.log.gz">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1.} - %m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="10 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="14"/>
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <Root level="${ROOT_LEVEL}">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Root>
+  </Loggers>
+  
+</Configuration>


### PR DESCRIPTION
Added dependencies for logging to pom.xml.
I'm using an abstraction system (SLF4J) so the underlying engine (Log4j2) can be replaced without many code changes.
Created the Log4j2.properties file to determine how to log.
Updated some misc files I saw with SHATU data instead of DPTU data.
Fixed path to mainClass in pom.xml.