### PR TITLE
Dptu 77 - Add logging imports and logging object across everything, resolve conflicts with JUL Logging.

### DIFF
--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -40,7 +40,7 @@ public class DpTuApp {
     // ./resources/logging.properties
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final Logger julLogger = Logger.getLogger(DpTuApp.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuApp.class.getName());
 
     /**
      * Main entry point for the DpTut application, which will display the UI.

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -13,12 +13,12 @@
 
 package edu.regis.dptu;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.LogManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.svc.DpTuServer;
 import edu.regis.dptu.util.ResourceMgr;
@@ -55,7 +55,10 @@ public class DpTuApp {
                 LogManager.getLogManager().readConfiguration(strm);
                 julLogger.info("Message logging initialization completed.");
             } else {
-                julLogger.severe("Logging.properties not found at " + julLogger_PROPERTIES + " on the classpath.");
+                julLogger.severe(
+                        "Logging.properties not found at "
+                                + julLogger_PROPERTIES
+                                + " on the classpath.");
             }
         } catch (IOException e) {
             julLogger.log(java.util.logging.Level.SEVERE, "Error loading logging.properties", e);

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -13,12 +13,12 @@
 
 package edu.regis.dptu;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.LogManager;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.svc.DpTuServer;
 import edu.regis.dptu.util.ResourceMgr;
@@ -37,41 +37,39 @@ public class DpTuApp {
     private static final String julLogger_PROPERTIES = "/Logging.properties";
 
     // ./resources/logging.properties
-
-    /** Events of interest occurring in this class are logged to this logger. */
+    /** Events of interest occurring in this class are logged to this JUL logger. */
     private static final java.util.logging.Logger julLogger =
             java.util.logging.Logger.getLogger(DpTuApp.class.getName());
 
     /**
-     * Main entry point for the DpTut application, which will display the UI.
+     * Main entry point for the DpTu application, which will display the UI.
      *
      * @param args ignored
      */
     public static void main(String[] args) {
-        julLogger.info("DpTuApp Initializing...:");
+        julLogger.info("DpTuApp initializing…");
 
-        try {
-            final InputStream strm = DpTuApp.class.getResourceAsStream(julLogger_PROPERTIES);
-
-            LogManager.getLogManager().readConfiguration(strm);
-
-            julLogger.info("Message logging initialization completed.");
+        // Load JUL configuration from classpath (optional while migrating to SLF4J/Log4j2)
+        try (InputStream strm = DpTuApp.class.getResourceAsStream(julLogger_PROPERTIES)) {
+            if (strm != null) {
+                LogManager.getLogManager().readConfiguration(strm);
+                julLogger.info("Message logging initialization completed.");
+            } else {
+                julLogger.severe("Logging.properties not found at " + julLogger_PROPERTIES + " on the classpath.");
+            }
         } catch (IOException e) {
-
-            julLogger.severe("Error loading ./logging.properties");
-            julLogger.severe(e.getMessage());
+            julLogger.log(java.util.logging.Level.SEVERE, "Error loading logging.properties", e);
         }
 
         // Initializes the properties from DpTu.properties and sets the locale.
         ResourceMgr.instance();
-
         julLogger.info("DpTu properties initialization completed.");
 
         try {
-            julLogger.info(" Starting DpTu Server (Tutoring Service)...");
+            julLogger.info("Starting DpTu Server (Tutoring Service)...");
             // ToDo: Separate the initialization of client and server
             // Start the socket server for the DpTu tutor.
-            (new Thread(new DpTuServer())).start();
+            new Thread(new DpTuServer()).start();
 
             // ToDo: This puts the main client UI thread to sleep to give the
             // server a chance to finish starting. This won't be required once
@@ -95,7 +93,8 @@ public class DpTuApp {
             julLogger.info("DpTu Initialization successful.");
 
         } catch (InterruptedException ex) {
-            Logger.getLogger(DpTuApp.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+            julLogger.log(java.util.logging.Level.SEVERE, "Interrupted during startup", ex);
+            Thread.currentThread().interrupt();
         } catch (SecurityException e) {
             julLogger.severe("Couldn't create Data directory in NetBeans Project.");
             julLogger.severe("Perhaps, try changing permissions.");

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -15,7 +15,7 @@ package edu.regis.dptu;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Level;
+
 import java.util.logging.LogManager;
 
 import org.slf4j.Logger;
@@ -96,7 +96,7 @@ public class DpTuApp {
             julLogger.info("DpTu Initialization successful.");
 
         } catch (InterruptedException ex) {
-            Logger.getLogger(DpTuApp.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(DpTuApp.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
         } catch (SecurityException e) {
             julLogger.severe("Couldn't create Data directory in NetBeans Project.");
             julLogger.severe("Perhaps, try changing permissions.");

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -15,7 +15,6 @@ package edu.regis.dptu;
 
 import java.io.IOException;
 import java.io.InputStream;
-
 import java.util.logging.LogManager;
 
 import org.slf4j.Logger;

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -34,13 +34,13 @@ import edu.regis.dptu.view.SplashFrame;
 public class DpTuApp {
     private static final Logger log = LoggerFactory.getLogger(DpTuApp.class);
 
-    /** Property file located on the CLASSPATH, which is used to configure the LOGGER. */
-    private static final String LOGGER_PROPERTIES = "/Logging.properties";
+    /** Property file located on the CLASSPATH, which is used to configure the julLogger. */
+    private static final String julLogger_PROPERTIES = "/Logging.properties";
 
     // ./resources/logging.properties
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final Logger LOGGER = Logger.getLogger(DpTuApp.class.getName());
+    private static final Logger julLogger = Logger.getLogger(DpTuApp.class.getName());
 
     /**
      * Main entry point for the DpTut application, which will display the UI.
@@ -48,27 +48,27 @@ public class DpTuApp {
      * @param args ignored
      */
     public static void main(String[] args) {
-        LOGGER.info("DpTuApp Initializing...:");
+        julLogger.info("DpTuApp Initializing...:");
 
         try {
-            final InputStream strm = DpTuApp.class.getResourceAsStream(LOGGER_PROPERTIES);
+            final InputStream strm = DpTuApp.class.getResourceAsStream(julLogger_PROPERTIES);
 
             LogManager.getLogManager().readConfiguration(strm);
 
-            LOGGER.info("Message logging initialization completed.");
+            julLogger.info("Message logging initialization completed.");
         } catch (IOException e) {
 
-            LOGGER.severe("Error loading ./logging.properties");
-            LOGGER.severe(e.getMessage());
+            julLogger.severe("Error loading ./logging.properties");
+            julLogger.severe(e.getMessage());
         }
 
         // Initializes the properties from DpTu.properties and sets the locale.
         ResourceMgr.instance();
 
-        LOGGER.info("DpTu properties initialization completed.");
+        julLogger.info("DpTu properties initialization completed.");
 
         try {
-            LOGGER.info(" Starting DpTu Server (Tutoring Service)...");
+            julLogger.info(" Starting DpTu Server (Tutoring Service)...");
             // ToDo: Separate the initialization of client and server
             // Start the socket server for the DpTu tutor.
             (new Thread(new DpTuServer())).start();
@@ -79,9 +79,9 @@ public class DpTuApp {
             // from the GUI client since the server should "always" be running.
             Thread.sleep(4000);
 
-            LOGGER.info(" Server is running.");
+            julLogger.info(" Server is running.");
 
-            LOGGER.info(" Starting Client GUI...");
+            julLogger.info(" Starting Client GUI...");
 
             // Force the creation of the MainFrame singleton, which is not
             // made visible to the user until after they sign-in.
@@ -92,13 +92,13 @@ public class DpTuApp {
             // If sign-in is successful the MainFrame is displayed.
             SplashFrame.instance();
 
-            LOGGER.info("DpTu Initialization successful.");
+            julLogger.info("DpTu Initialization successful.");
 
         } catch (InterruptedException ex) {
             Logger.getLogger(DpTuApp.class.getName()).log(Level.SEVERE, null, ex);
         } catch (SecurityException e) {
-            LOGGER.severe("Couldn't create Data directory in NetBeans Project.");
-            LOGGER.severe("Perhaps, try changing permissions.");
+            julLogger.severe("Couldn't create Data directory in NetBeans Project.");
+            julLogger.severe("Perhaps, try changing permissions.");
         }
     }
 }

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -40,7 +40,8 @@ public class DpTuApp {
     // ./resources/logging.properties
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuApp.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(DpTuApp.class.getName());
 
     /**
      * Main entry point for the DpTut application, which will display the UI.

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -13,6 +13,9 @@
 
 package edu.regis.dptu;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
@@ -30,6 +33,8 @@ import edu.regis.dptu.view.SplashFrame;
  * @author rickb
  */
 public class DpTuApp {
+    private static final Logger log = LoggerFactory.getLogger(DpTuApp.class);
+
     /** Property file located on the CLASSPATH, which is used to configure the LOGGER. */
     private static final String LOGGER_PROPERTIES = "/Logging.properties";
 

--- a/src/main/java/edu/regis/dptu/DpTuApp.java
+++ b/src/main/java/edu/regis/dptu/DpTuApp.java
@@ -13,14 +13,14 @@
 
 package edu.regis.dptu;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.svc.DpTuServer;
 import edu.regis.dptu.util.ResourceMgr;

--- a/src/main/java/edu/regis/dptu/dao/AccountDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/AccountDAO.java
@@ -12,6 +12,8 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -30,6 +32,8 @@ import edu.regis.dptu.svc.AccountSvc;
  * @author rickb
  */
 public class AccountDAO extends MySqlDAO implements AccountSvc {
+    private static final Logger log = LoggerFactory.getLogger(AccountDAO.class);
+
 
     /** Initialize this DAO via the parent constructor. */
     public AccountDAO() {

--- a/src/main/java/edu/regis/dptu/dao/AccountDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/AccountDAO.java
@@ -12,14 +12,14 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;
@@ -34,7 +34,6 @@ import edu.regis.dptu.svc.AccountSvc;
  */
 public class AccountDAO extends MySqlDAO implements AccountSvc {
     private static final Logger log = LoggerFactory.getLogger(AccountDAO.class);
-
 
     /** Initialize this DAO via the parent constructor. */
     public AccountDAO() {

--- a/src/main/java/edu/regis/dptu/dao/AccountDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/AccountDAO.java
@@ -12,6 +12,7 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;

--- a/src/main/java/edu/regis/dptu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -49,6 +52,8 @@ import edu.regis.dptu.svc.ServiceFactory;
  * @author rickb
  */
 public class CourseDAO extends MySqlDAO implements CourseSvc {
+    private static final Logger log = LoggerFactory.getLogger(CourseDAO.class);
+
 
     /** Instantiate this Course DAO with default values. */
     public CourseDAO() {}

--- a/src/main/java/edu/regis/dptu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDAO.java
@@ -12,15 +12,15 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.InconsistentDBException;
 import edu.regis.dptu.err.NonRecoverableException;
@@ -53,7 +53,6 @@ import edu.regis.dptu.svc.ServiceFactory;
  */
 public class CourseDAO extends MySqlDAO implements CourseSvc {
     private static final Logger log = LoggerFactory.getLogger(CourseDAO.class);
-
 
     /** Instantiate this Course DAO with default values. */
     public CourseDAO() {}

--- a/src/main/java/edu/regis/dptu/dao/CourseDigestDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDigestDAO.java
@@ -12,14 +12,14 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;

--- a/src/main/java/edu/regis/dptu/dao/CourseDigestDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDigestDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -30,6 +33,8 @@ import edu.regis.dptu.model.TaskSelectionKind;
  * @author benm
  */
 public class CourseDigestDAO extends MySqlDAO {
+    private static final Logger log = LoggerFactory.getLogger(CourseDigestDAO.class);
+
     /** Initialize this DAO via the parent constructor. */
     public CourseDigestDAO() {
         super();

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -51,7 +51,8 @@ public abstract class MySqlDAO {
      */
     public static String URL;
 
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(MySqlDAO.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(MySqlDAO.class.getName());
 
     /**
      * Utility indicating whether the DriverClass was explictly loaded (in order to overcome errors

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -12,13 +12,13 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.MissingPropertyException;
 import edu.regis.dptu.util.ResourceMgr;

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -16,7 +16,6 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -15,7 +15,7 @@ package edu.regis.dptu.dao;
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -15,7 +15,6 @@ package edu.regis.dptu.dao;
 import java.sql.Connection;
 import java.sql.Statement;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,14 +89,18 @@ public abstract class MySqlDAO {
                 IS_LOADED = true;
 
             } catch (MissingPropertyException e) {
-                julLogger.log(java.util.logging.Level.INFO, "Missing DB property: {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.INFO, "Missing DB property: {0}", e.toString());
             } catch (ClassNotFoundException e) {
                 julLogger.log(
                         java.util.logging.Level.SEVERE,
                         "MySqlDao-ERR-1: Illegal driver class name {0}",
                         e.toString());
             } catch (InstantiationException e) {
-                julLogger.log(java.util.logging.Level.SEVERE, "MySqlDao-ERR-2: Illegal instance {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.SEVERE,
+                        "MySqlDao-ERR-2: Illegal instance {0}",
+                        e.toString());
             } catch (IllegalAccessException e) {
                 julLogger.log(
                         java.util.logging.Level.SEVERE,
@@ -119,7 +122,10 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-4: stmt.close() {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.INFO,
+                        "MySqlDao-ERR-4: stmt.close() {0}",
+                        e.toString());
             }
         }
 
@@ -127,7 +133,8 @@ public abstract class MySqlDAO {
             try {
                 conn.close();
             } catch (Exception e) {
-                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
             }
         }
     }
@@ -144,7 +151,8 @@ public abstract class MySqlDAO {
                 conn.setAutoCommit(true); // Convenience
                 conn.close();
             } catch (Exception e) {
-                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
             }
         }
     }
@@ -160,7 +168,8 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
+                julLogger.log(
+                        java.util.logging.Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
             }
         }
     }

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -51,7 +51,7 @@ public abstract class MySqlDAO {
      */
     public static String URL;
 
-    private static final Logger julLogger = Logger.getLogger(MySqlDAO.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(MySqlDAO.class.getName());
 
     /**
      * Utility indicating whether the DriverClass was explictly loaded (in order to overcome errors

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -51,7 +51,7 @@ public abstract class MySqlDAO {
      */
     public static String URL;
 
-    private static final Logger LOGGER = Logger.getLogger(MySqlDAO.class.getName());
+    private static final Logger julLogger = Logger.getLogger(MySqlDAO.class.getName());
 
     /**
      * Utility indicating whether the DriverClass was explictly loaded (in order to overcome errors
@@ -89,16 +89,16 @@ public abstract class MySqlDAO {
                 IS_LOADED = true;
 
             } catch (MissingPropertyException e) {
-                LOGGER.log(Level.INFO, "Missing DB property: {0}", e.toString());
+                julLogger.log(Level.INFO, "Missing DB property: {0}", e.toString());
             } catch (ClassNotFoundException e) {
-                LOGGER.log(
+                julLogger.log(
                         Level.SEVERE,
                         "MySqlDao-ERR-1: Illegal driver class name {0}",
                         e.toString());
             } catch (InstantiationException e) {
-                LOGGER.log(Level.SEVERE, "MySqlDao-ERR-2: Illegal instance {0}", e.toString());
+                julLogger.log(Level.SEVERE, "MySqlDao-ERR-2: Illegal instance {0}", e.toString());
             } catch (IllegalAccessException e) {
-                LOGGER.log(
+                julLogger.log(
                         Level.SEVERE,
                         "MySqlDao-ERR-3: No create driver permission {0}",
                         e.toString());
@@ -118,7 +118,7 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "MySqlDao-ERR-4: stmt.close() {0}", e.toString());
+                julLogger.log(Level.INFO, "MySqlDao-ERR-4: stmt.close() {0}", e.toString());
             }
         }
 
@@ -126,7 +126,7 @@ public abstract class MySqlDAO {
             try {
                 conn.close();
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
+                julLogger.log(Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
             }
         }
     }
@@ -143,7 +143,7 @@ public abstract class MySqlDAO {
                 conn.setAutoCommit(true); // Convenience
                 conn.close();
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
+                julLogger.log(Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
             }
         }
     }
@@ -159,7 +159,7 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
+                julLogger.log(Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
             }
         }
     }

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -14,7 +14,7 @@ package edu.regis.dptu.dao;
 
 import java.sql.Connection;
 import java.sql.Statement;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,17 +90,17 @@ public abstract class MySqlDAO {
                 IS_LOADED = true;
 
             } catch (MissingPropertyException e) {
-                julLogger.log(Level.INFO, "Missing DB property: {0}", e.toString());
+                julLogger.log(java.util.logging.Level.INFO, "Missing DB property: {0}", e.toString());
             } catch (ClassNotFoundException e) {
                 julLogger.log(
-                        Level.SEVERE,
+                        java.util.logging.Level.SEVERE,
                         "MySqlDao-ERR-1: Illegal driver class name {0}",
                         e.toString());
             } catch (InstantiationException e) {
-                julLogger.log(Level.SEVERE, "MySqlDao-ERR-2: Illegal instance {0}", e.toString());
+                julLogger.log(java.util.logging.Level.SEVERE, "MySqlDao-ERR-2: Illegal instance {0}", e.toString());
             } catch (IllegalAccessException e) {
                 julLogger.log(
-                        Level.SEVERE,
+                        java.util.logging.Level.SEVERE,
                         "MySqlDao-ERR-3: No create driver permission {0}",
                         e.toString());
             }
@@ -119,7 +119,7 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                julLogger.log(Level.INFO, "MySqlDao-ERR-4: stmt.close() {0}", e.toString());
+                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-4: stmt.close() {0}", e.toString());
             }
         }
 
@@ -127,7 +127,7 @@ public abstract class MySqlDAO {
             try {
                 conn.close();
             } catch (Exception e) {
-                julLogger.log(Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
+                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-5: close() {0}", e.toString());
             }
         }
     }
@@ -144,7 +144,7 @@ public abstract class MySqlDAO {
                 conn.setAutoCommit(true); // Convenience
                 conn.close();
             } catch (Exception e) {
-                julLogger.log(Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
+                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-6: close() {0}", e.toString());
             }
         }
     }
@@ -160,7 +160,7 @@ public abstract class MySqlDAO {
             try {
                 stmt.close();
             } catch (Exception e) {
-                julLogger.log(Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
+                julLogger.log(java.util.logging.Level.INFO, "MySqlDao-ERR-7: close() {0}", e.toString());
             }
         }
     }

--- a/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/MySqlDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.logging.Level;
@@ -27,6 +30,8 @@ import edu.regis.dptu.util.ResourceMgr;
  * @author Rickb
  */
 public abstract class MySqlDAO {
+    private static final Logger log = LoggerFactory.getLogger(MySqlDAO.class);
+
     /** The host where MySQL resides (see /resources/DpTu.Properties). */
     public static final String DB_HOST_PROP = "edu.regis.dptu.DB_HOST";
 

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -26,6 +29,8 @@ import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.svc.ProblemSvc;
 
 public class ProblemDAO extends MySqlDAO implements ProblemSvc {
+    private static final Logger log = LoggerFactory.getLogger(ProblemDAO.class);
+
 
     /** Instantiate this Course DAO with default values. */
     public ProblemDAO() {}

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -12,14 +12,14 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
@@ -30,7 +30,6 @@ import edu.regis.dptu.svc.ProblemSvc;
 
 public class ProblemDAO extends MySqlDAO implements ProblemSvc {
     private static final Logger log = LoggerFactory.getLogger(ProblemDAO.class);
-
 
     /** Instantiate this Course DAO with default values. */
     public ProblemDAO() {}

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -35,6 +38,8 @@ import edu.regis.dptu.svc.SessionSvc;
  * @author rickb
  */
 public class SessionDAO extends MySqlDAO implements SessionSvc {
+    private static final Logger log = LoggerFactory.getLogger(SessionDAO.class);
+
     /** Initialize this DAO via the parent constructor. */
     public SessionDAO() {
         super();

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -12,15 +12,15 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.GregorianCalendar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -45,7 +45,7 @@ import edu.regis.dptu.svc.StudentModelSvc;
 public class StudentModelDAO extends Transactionable implements StudentModelSvc {
     private static final Logger log = LoggerFactory.getLogger(StudentModelDAO.class);
 
-    private static final Logger julLogger = Logger.getLogger(StudentModelDAO.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(StudentModelDAO.class.getName());
 
     /** Initialize this DAO via the parent constructor. */
     public StudentModelDAO() {

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -45,7 +45,7 @@ import edu.regis.dptu.svc.StudentModelSvc;
 public class StudentModelDAO extends Transactionable implements StudentModelSvc {
     private static final Logger log = LoggerFactory.getLogger(StudentModelDAO.class);
 
-    private static final Logger LOGGER = Logger.getLogger(StudentModelDAO.class.getName());
+    private static final Logger julLogger = Logger.getLogger(StudentModelDAO.class.getName());
 
     /** Initialize this DAO via the parent constructor. */
     public StudentModelDAO() {
@@ -210,12 +210,12 @@ public class StudentModelDAO extends Transactionable implements StudentModelSvc 
                     break;
             }
 
-            LOGGER.log(Level.FINE, "Executing statement: {0}", stmt.toString());
+            julLogger.log(Level.FINE, "Executing statement: {0}", stmt.toString());
 
             stmt.execute();
 
         } catch (SQLException e) {
-            LOGGER.log(
+            julLogger.log(
                     Level.SEVERE,
                     "SQL Error - State: {0}, Code: {1}",
                     new Object[] {e.getSQLState(), e.getErrorCode()});

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -9,7 +9,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -45,7 +45,8 @@ import edu.regis.dptu.svc.StudentModelSvc;
 public class StudentModelDAO extends Transactionable implements StudentModelSvc {
     private static final Logger log = LoggerFactory.getLogger(StudentModelDAO.class);
 
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(StudentModelDAO.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(StudentModelDAO.class.getName());
 
     /** Initialize this DAO via the parent constructor. */
     public StudentModelDAO() {

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -1,5 +1,8 @@
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -41,6 +44,8 @@ import edu.regis.dptu.svc.StudentModelSvc;
  * @author rickb
  */
 public class StudentModelDAO extends Transactionable implements StudentModelSvc {
+    private static final Logger log = LoggerFactory.getLogger(StudentModelDAO.class);
+
 
     private static final Logger LOGGER = Logger.getLogger(StudentModelDAO.class.getName());
 

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -8,7 +8,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,13 +211,13 @@ public class StudentModelDAO extends Transactionable implements StudentModelSvc 
                     break;
             }
 
-            julLogger.log(Level.FINE, "Executing statement: {0}", stmt.toString());
+            julLogger.log(java.util.logging.Level.FINE, "Executing statement: {0}", stmt.toString());
 
             stmt.execute();
 
         } catch (SQLException e) {
             julLogger.log(
-                    Level.SEVERE,
+                    java.util.logging.Level.SEVERE,
                     "SQL Error - State: {0}, Code: {1}",
                     new Object[] {e.getSQLState(), e.getErrorCode()});
             throw new NonRecoverableException("StudentModelDAO-ERR-4" + e.toString(), e);

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -1,8 +1,5 @@
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -13,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
@@ -45,7 +45,6 @@ import edu.regis.dptu.svc.StudentModelSvc;
  */
 public class StudentModelDAO extends Transactionable implements StudentModelSvc {
     private static final Logger log = LoggerFactory.getLogger(StudentModelDAO.class);
-
 
     private static final Logger LOGGER = Logger.getLogger(StudentModelDAO.class.getName());
 

--- a/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/StudentModelDAO.java
@@ -9,7 +9,6 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,7 +210,8 @@ public class StudentModelDAO extends Transactionable implements StudentModelSvc 
                     break;
             }
 
-            julLogger.log(java.util.logging.Level.FINE, "Executing statement: {0}", stmt.toString());
+            julLogger.log(
+                    java.util.logging.Level.FINE, "Executing statement: {0}", stmt.toString());
 
             stmt.execute();
 

--- a/src/main/java/edu/regis/dptu/dao/Transactionable.java
+++ b/src/main/java/edu/regis/dptu/dao/Transactionable.java
@@ -1,5 +1,8 @@
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -12,6 +15,8 @@ import edu.regis.dptu.err.NonRecoverableException;
  * @author benm
  */
 public abstract class Transactionable extends MySqlDAO {
+    private static final Logger log = LoggerFactory.getLogger(Transactionable.class);
+
     /**
      * Start a transaction on the connection
      *

--- a/src/main/java/edu/regis/dptu/dao/Transactionable.java
+++ b/src/main/java/edu/regis/dptu/dao/Transactionable.java
@@ -1,10 +1,10 @@
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.NonRecoverableException;
 

--- a/src/main/java/edu/regis/dptu/dao/UnitDigestDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/UnitDigestDAO.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.dao;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -30,6 +33,8 @@ import edu.regis.dptu.model.UnitDigest;
  * @author benm
  */
 public class UnitDigestDAO extends MySqlDAO {
+    private static final Logger log = LoggerFactory.getLogger(UnitDigestDAO.class);
+
     /** Initialize this DAO via the parent constructor. */
     public UnitDigestDAO() {
         super();

--- a/src/main/java/edu/regis/dptu/dao/UnitDigestDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/UnitDigestDAO.java
@@ -12,14 +12,14 @@
  */
 package edu.regis.dptu.dao;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;

--- a/src/main/java/edu/regis/dptu/err/DpTuException.java
+++ b/src/main/java/edu/regis/dptu/err/DpTuException.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Root of all checked DpTu application exceptions.
  *
@@ -21,6 +24,8 @@ package edu.regis.dptu.err;
  * @author Rickb
  */
 public abstract class DpTuException extends Exception {
+    private static final Logger log = LoggerFactory.getLogger(DpTuException.class);
+
     /**
      * Initialize this new instance with the given message.
      *

--- a/src/main/java/edu/regis/dptu/err/IllegalArgException.java
+++ b/src/main/java/edu/regis/dptu/err/IllegalArgException.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Thrown when an illegal argument was passed to a method.
  *
  * @author rickb
  */
 public class IllegalArgException extends DpTuException {
+    private static final Logger log = LoggerFactory.getLogger(IllegalArgException.class);
+
     /**
      * Initialize this exception with the given message.
      *

--- a/src/main/java/edu/regis/dptu/err/InconsistentDBException.java
+++ b/src/main/java/edu/regis/dptu/err/InconsistentDBException.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Thrown when there is an inconsistency in the database, which should never happen (a programmer
  * error).
@@ -19,6 +22,8 @@ package edu.regis.dptu.err;
  * @author rickb
  */
 public class InconsistentDBException extends NonRecoverableException {
+    private static final Logger log = LoggerFactory.getLogger(InconsistentDBException.class);
+
     /**
      * Initialize this new instance with the given message and log the exception.
      *

--- a/src/main/java/edu/regis/dptu/err/MissingPropertyException.java
+++ b/src/main/java/edu/regis/dptu/err/MissingPropertyException.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Thrown when a property cannot be found in a "*.properties" file.
  *
@@ -21,6 +24,8 @@ package edu.regis.dptu.err;
  * @author rickb
  */
 public class MissingPropertyException extends DpTuException {
+    private static final Logger log = LoggerFactory.getLogger(MissingPropertyException.class);
+
     /**
      * Construct this new instance with the given message.
      *

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -12,11 +12,11 @@
  */
 package edu.regis.dptu.err;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An unexpected exception that the user cannot recovered from, which is logged.

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -14,7 +14,6 @@ package edu.regis.dptu.err;
 
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -12,8 +12,6 @@
  */
 package edu.regis.dptu.err;
 
-import java.util.logging.Level;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +26,8 @@ import org.slf4j.LoggerFactory;
  */
 public class NonRecoverableException extends DpTuException {
     private static final Logger log = LoggerFactory.getLogger(NonRecoverableException.class);
+    private static final java.util.logging.Logger julLogger =
+        java.util.logging.Logger.getLogger(NonRecoverableException.class.getName());
 
     /**
      * Initialize this new instance with the given message and log the exception.
@@ -37,8 +37,7 @@ public class NonRecoverableException extends DpTuException {
     public NonRecoverableException(String msg) {
         super(msg);
 
-        Logger.getLogger(NonRecoverableException.class.getName())
-                .log(Level.SEVERE, "DpTuException: {0}", msg);
+        julLogger.log(java.util.logging.Level.SEVERE, "DpTuException: {0}", msg);
     }
 
     /**
@@ -51,6 +50,6 @@ public class NonRecoverableException extends DpTuException {
     public NonRecoverableException(String msg, Throwable cause) {
         super(msg, cause);
 
-        Logger.getLogger(NonRecoverableException.class.getName()).log(Level.SEVERE, msg, cause);
+        julLogger.log(java.util.logging.Level.SEVERE, msg, cause);
     }
 }

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 public class NonRecoverableException extends DpTuException {
     private static final Logger log = LoggerFactory.getLogger(NonRecoverableException.class);
     private static final java.util.logging.Logger julLogger =
-        java.util.logging.Logger.getLogger(NonRecoverableException.class.getName());
+            java.util.logging.Logger.getLogger(NonRecoverableException.class.getName());
 
     /**
      * Initialize this new instance with the given message and log the exception.

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,6 +28,8 @@ import java.util.logging.Logger;
  * @author rickb
  */
 public class NonRecoverableException extends DpTuException {
+    private static final Logger log = LoggerFactory.getLogger(NonRecoverableException.class);
+
     /**
      * Initialize this new instance with the given message and log the exception.
      *

--- a/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
+++ b/src/main/java/edu/regis/dptu/err/NonRecoverableException.java
@@ -13,7 +13,7 @@
 package edu.regis.dptu.err;
 
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/err/ObjNotFoundException.java
+++ b/src/main/java/edu/regis/dptu/err/ObjNotFoundException.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Thrown when an object isn't found (context specific).
  *
  * @author rickb
  */
 public class ObjNotFoundException extends DpTuException {
+    private static final Logger log = LoggerFactory.getLogger(ObjNotFoundException.class);
+
     /**
      * Initialize this exception with the given message.
      *

--- a/src/main/java/edu/regis/dptu/err/XmlException.java
+++ b/src/main/java/edu/regis/dptu/err/XmlException.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.err;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Thrown when an unexpected, non-recoverable error occurred associated with processing an XML file
  * in the XmlMgr.
@@ -19,6 +22,8 @@ package edu.regis.dptu.err;
  * @author Rickb
  */
 public class XmlException extends DpTuException {
+    private static final Logger log = LoggerFactory.getLogger(XmlException.class);
+
     /**
      * Initialize this exception with the given message.
      *

--- a/src/main/java/edu/regis/dptu/model/Account.java
+++ b/src/main/java/edu/regis/dptu/model/Account.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A Decorator wrapping user and student information sans the student model.
  *
@@ -21,6 +24,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class Account {
+    private static final Logger log = LoggerFactory.getLogger(Account.class);
+
     /** The user's login id (e.g. "name@university.edu"). */
     protected String userId;
 

--- a/src/main/java/edu/regis/dptu/model/Course.java
+++ b/src/main/java/edu/regis/dptu/model/Course.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
 import edu.regis.dptu.err.ObjNotFoundException;
@@ -22,6 +25,8 @@ import edu.regis.dptu.err.ObjNotFoundException;
  * @author rickb
  */
 public class Course extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(Course.class);
+
     /**
      * The primary pedagogical approach initially used to start task selection.
      *

--- a/src/main/java/edu/regis/dptu/model/Course.java
+++ b/src/main/java/edu/regis/dptu/model/Course.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 
 import edu.regis.dptu.err.ObjNotFoundException;
 

--- a/src/main/java/edu/regis/dptu/model/CourseDigest.java
+++ b/src/main/java/edu/regis/dptu/model/CourseDigest.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A descriptive summary of a course as used in a tutoring session, which eliminates the need to
  * return an entire course to the GUI.
@@ -19,6 +22,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class CourseDigest extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(CourseDigest.class);
+
     /** The primary pedagogical approach initially used to start task selection. */
     private TaskSelectionKind primaryPedagogy;
 

--- a/src/main/java/edu/regis/dptu/model/ExercisingLocation.java
+++ b/src/main/java/edu/regis/dptu/model/ExercisingLocation.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Specifies the course, unit, task, and step that pedagogically addresses a knowledge component.
  *
@@ -19,6 +22,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class ExercisingLocation extends Model {
+    private static final Logger log = LoggerFactory.getLogger(ExercisingLocation.class);
+
     /** The id of the associated course. */
     private int courseId;
 

--- a/src/main/java/edu/regis/dptu/model/Hint.java
+++ b/src/main/java/edu/regis/dptu/model/Hint.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A suggestion as to the next Step the Student should perform in the tutor.
  *
  * @author rickb
  */
 public class Hint extends Model {
+    private static final Logger log = LoggerFactory.getLogger(Hint.class);
+
     // Todo: level? Scaffolding??
 
     /** The hint string, which can be displayed to the student user. */

--- a/src/main/java/edu/regis/dptu/model/InformationStep.java
+++ b/src/main/java/edu/regis/dptu/model/InformationStep.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A step subtype in which the student must acknowledge a message from the tutor.
  *
  * @author rickb
  */
 public class InformationStep {
+    private static final Logger log = LoggerFactory.getLogger(InformationStep.class);
+
     /** The message the student must acknowledge. */
     private String msg;
 

--- a/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
+++ b/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
 import edu.regis.dptu.model.aol.OutcomeGranularity;
@@ -25,6 +28,8 @@ import edu.regis.dptu.model.aol.OutcomeGranularity;
  * @author rickb
  */
 public class KnowledgeComponent extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(KnowledgeComponent.class);
+
     /** The Bloom Level associated with this outcome. */
     protected BloomLevel bloomLevel;
 

--- a/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
+++ b/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 
 import edu.regis.dptu.model.aol.OutcomeGranularity;
 

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -39,7 +39,7 @@ public class LCSProblem extends Problem {
     private static final Logger log = LoggerFactory.getLogger(LCSProblem.class);
 
     /** The logger for the class */
-    private static final Logger julLogger = Logger.getLogger(LCSProblem.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(LCSProblem.class.getName());
 
     /**
      * Current state of execution capturing which of the loops are current. Note if the

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -13,7 +13,7 @@
 package edu.regis.dptu.model;
 
 import java.util.Iterator;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -335,24 +335,24 @@ public class LCSProblem extends Problem {
      */
     public void prettyPrint() {
         // Original prettyPrint code retained
-        LCSProblem.julLogger.log(Level.INFO, "--- LCSProblem State ---");
-        LCSProblem.julLogger.log(Level.INFO, "ExecutionState: " + executionState);
-        LCSProblem.julLogger.log(Level.INFO, "Current Line #: " + nextLineNumber);
-        LCSProblem.julLogger.log(Level.INFO, "r (array idx): " + variables.get("r"));
-        LCSProblem.julLogger.log(Level.INFO, "c (array idx): " + variables.get("c"));
-        LCSProblem.julLogger.log(Level.INFO, "i (array idx): " + variables.get("i"));
-        LCSProblem.julLogger.log(Level.INFO, "j (array idx): " + variables.get("j"));
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "--- LCSProblem State ---");
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "ExecutionState: " + executionState);
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "Current Line #: " + nextLineNumber);
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "r (array idx): " + variables.get("r"));
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "c (array idx): " + variables.get("c"));
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "i (array idx): " + variables.get("i"));
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "j (array idx): " + variables.get("j"));
 
         int n = (int) variables.get("n");
         int m = (int) variables.get("m");
         int[][] subproblemL = (int[][]) variables.get("l");
 
-        LCSProblem.julLogger.log(Level.INFO, "DP Table (l):");
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "DP Table (l):");
         System.out.print("       "); // Align header
         for (int q = 0; q <= m; q++) {
             System.out.printf("%4d ", q - 1); // Print DP Col Index (-1 to m-1)
         }
-        LCSProblem.julLogger.log(Level.INFO, "");
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "");
 
         for (int p = 0; p <= n; p++) {
             System.out.printf("%4d | ", p - 1); // Print DP Row Index (-1 to n-1)
@@ -361,9 +361,9 @@ public class LCSProblem extends Problem {
                 System.out.printf(
                         "%4s ", (val == -1 ? "." : String.valueOf(val))); // Use '.' for uncomputed
             }
-            LCSProblem.julLogger.log(Level.INFO, "|");
+            LCSProblem.julLogger.log(java.util.logging.Level.INFO, "|");
         }
-        LCSProblem.julLogger.log(Level.INFO, "------------------------");
+        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "------------------------");
     }
 
     // -----------------------LCS Algorithm--------------------------------------

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -14,7 +14,7 @@ package edu.regis.dptu.model;
 
 import java.util.Iterator;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,6 +37,8 @@ import java.util.logging.Logger;
  * @author rickb
  */
 public class LCSProblem extends Problem {
+    private static final Logger log = LoggerFactory.getLogger(LCSProblem.class);
+
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(LCSProblem.class.getName());

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -14,7 +14,6 @@ package edu.regis.dptu.model;
 
 import java.util.Iterator;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -338,10 +337,14 @@ public class LCSProblem extends Problem {
         LCSProblem.julLogger.log(java.util.logging.Level.INFO, "--- LCSProblem State ---");
         LCSProblem.julLogger.log(java.util.logging.Level.INFO, "ExecutionState: " + executionState);
         LCSProblem.julLogger.log(java.util.logging.Level.INFO, "Current Line #: " + nextLineNumber);
-        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "r (array idx): " + variables.get("r"));
-        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "c (array idx): " + variables.get("c"));
-        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "i (array idx): " + variables.get("i"));
-        LCSProblem.julLogger.log(java.util.logging.Level.INFO, "j (array idx): " + variables.get("j"));
+        LCSProblem.julLogger.log(
+                java.util.logging.Level.INFO, "r (array idx): " + variables.get("r"));
+        LCSProblem.julLogger.log(
+                java.util.logging.Level.INFO, "c (array idx): " + variables.get("c"));
+        LCSProblem.julLogger.log(
+                java.util.logging.Level.INFO, "i (array idx): " + variables.get("i"));
+        LCSProblem.julLogger.log(
+                java.util.logging.Level.INFO, "j (array idx): " + variables.get("j"));
 
         int n = (int) variables.get("n");
         int m = (int) variables.get("m");

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -12,12 +12,12 @@
  */
 package edu.regis.dptu.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a Longest Common Subsequence Dynamic Programming problem with inputs sequences
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
  */
 public class LCSProblem extends Problem {
     private static final Logger log = LoggerFactory.getLogger(LCSProblem.class);
-
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(LCSProblem.class.getName());

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -15,7 +15,6 @@ package edu.regis.dptu.model;
 import java.util.Iterator;
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -39,7 +39,8 @@ public class LCSProblem extends Problem {
     private static final Logger log = LoggerFactory.getLogger(LCSProblem.class);
 
     /** The logger for the class */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(LCSProblem.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(LCSProblem.class.getName());
 
     /**
      * Current state of execution capturing which of the loops are current. Note if the

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -39,7 +39,7 @@ public class LCSProblem extends Problem {
     private static final Logger log = LoggerFactory.getLogger(LCSProblem.class);
 
     /** The logger for the class */
-    private static final Logger LOGGER = Logger.getLogger(LCSProblem.class.getName());
+    private static final Logger julLogger = Logger.getLogger(LCSProblem.class.getName());
 
     /**
      * Current state of execution capturing which of the loops are current. Note if the
@@ -334,24 +334,24 @@ public class LCSProblem extends Problem {
      */
     public void prettyPrint() {
         // Original prettyPrint code retained
-        LCSProblem.LOGGER.log(Level.INFO, "--- LCSProblem State ---");
-        LCSProblem.LOGGER.log(Level.INFO, "ExecutionState: " + executionState);
-        LCSProblem.LOGGER.log(Level.INFO, "Current Line #: " + nextLineNumber);
-        LCSProblem.LOGGER.log(Level.INFO, "r (array idx): " + variables.get("r"));
-        LCSProblem.LOGGER.log(Level.INFO, "c (array idx): " + variables.get("c"));
-        LCSProblem.LOGGER.log(Level.INFO, "i (array idx): " + variables.get("i"));
-        LCSProblem.LOGGER.log(Level.INFO, "j (array idx): " + variables.get("j"));
+        LCSProblem.julLogger.log(Level.INFO, "--- LCSProblem State ---");
+        LCSProblem.julLogger.log(Level.INFO, "ExecutionState: " + executionState);
+        LCSProblem.julLogger.log(Level.INFO, "Current Line #: " + nextLineNumber);
+        LCSProblem.julLogger.log(Level.INFO, "r (array idx): " + variables.get("r"));
+        LCSProblem.julLogger.log(Level.INFO, "c (array idx): " + variables.get("c"));
+        LCSProblem.julLogger.log(Level.INFO, "i (array idx): " + variables.get("i"));
+        LCSProblem.julLogger.log(Level.INFO, "j (array idx): " + variables.get("j"));
 
         int n = (int) variables.get("n");
         int m = (int) variables.get("m");
         int[][] subproblemL = (int[][]) variables.get("l");
 
-        LCSProblem.LOGGER.log(Level.INFO, "DP Table (l):");
+        LCSProblem.julLogger.log(Level.INFO, "DP Table (l):");
         System.out.print("       "); // Align header
         for (int q = 0; q <= m; q++) {
             System.out.printf("%4d ", q - 1); // Print DP Col Index (-1 to m-1)
         }
-        LCSProblem.LOGGER.log(Level.INFO, "");
+        LCSProblem.julLogger.log(Level.INFO, "");
 
         for (int p = 0; p <= n; p++) {
             System.out.printf("%4d | ", p - 1); // Print DP Row Index (-1 to n-1)
@@ -360,9 +360,9 @@ public class LCSProblem extends Problem {
                 System.out.printf(
                         "%4s ", (val == -1 ? "." : String.valueOf(val))); // Use '.' for uncomputed
             }
-            LCSProblem.LOGGER.log(Level.INFO, "|");
+            LCSProblem.julLogger.log(Level.INFO, "|");
         }
-        LCSProblem.LOGGER.log(Level.INFO, "------------------------");
+        LCSProblem.julLogger.log(Level.INFO, "------------------------");
     }
 
     // -----------------------LCS Algorithm--------------------------------------

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -12,11 +12,11 @@
  */
 package edu.regis.dptu.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Stack;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * MatrixChainProblem implements the dynamic programming algorithm for the Matrix Chain
@@ -30,7 +30,6 @@ import java.util.Stack;
  */
 public class MatrixChainProblem extends Problem {
     private static final Logger log = LoggerFactory.getLogger(MatrixChainProblem.class);
-
 
     /**
      * Enumeration of execution states corresponding to each loop or phase in the matrix chain

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Stack;
 
@@ -26,6 +29,8 @@ import java.util.Stack;
  * @author Corey Brantley
  */
 public class MatrixChainProblem extends Problem {
+    private static final Logger log = LoggerFactory.getLogger(MatrixChainProblem.class);
+
 
     /**
      * Enumeration of execution states corresponding to each loop or phase in the matrix chain

--- a/src/main/java/edu/regis/dptu/model/Model.java
+++ b/src/main/java/edu/regis/dptu/model/Model.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.io.Serializable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
 
 /**
  * A domain model with a unique id

--- a/src/main/java/edu/regis/dptu/model/Model.java
+++ b/src/main/java/edu/regis/dptu/model/Model.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 
 /**
@@ -22,6 +25,8 @@ import java.io.Serializable;
  * @author rickb
  */
 public abstract class Model implements Serializable {
+    private static final Logger log = LoggerFactory.getLogger(Model.class);
+
     /** A default identifier indicating a model that has not been saved to the database. */
     public static final int DEFAULT_ID = -1;
 

--- a/src/main/java/edu/regis/dptu/model/PendingStep.java
+++ b/src/main/java/edu/regis/dptu/model/PendingStep.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
 /**
@@ -24,6 +27,8 @@ import java.util.ArrayList;
  * @author rickb
  */
 public class PendingStep {
+    private static final Logger log = LoggerFactory.getLogger(PendingStep.class);
+
     /** The auto-generated database id for this pending step. */
     private int id;
 

--- a/src/main/java/edu/regis/dptu/model/PendingStep.java
+++ b/src/main/java/edu/regis/dptu/model/PendingStep.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 
 /**
  * The current step within a pending task that a student needs to complete as part of the current

--- a/src/main/java/edu/regis/dptu/model/PendingTask.java
+++ b/src/main/java/edu/regis/dptu/model/PendingTask.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A task that a student needs to complete as part of the current tutoring session (this may be the
  * current task or one that is still to be completed).
@@ -22,6 +25,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class PendingTask {
+    private static final Logger log = LoggerFactory.getLogger(PendingTask.class);
+
     /** The static course task that is associated with this pending task. */
     private Task task;
 

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -40,7 +40,8 @@ public abstract class Problem extends TitledModel {
     private static final int RUN_STEP_INTERVAL = 500;
 
     /** The logger for the class */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(Problem.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(Problem.class.getName());
 
     /**
      * The type of this Dynamic Programming problem, which must be assigned when instantiating a

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -40,7 +40,7 @@ public abstract class Problem extends TitledModel {
     private static final int RUN_STEP_INTERVAL = 500;
 
     /** The logger for the class */
-    private static final Logger LOGGER = Logger.getLogger(Problem.class.getName());
+    private static final Logger julLogger = Logger.getLogger(Problem.class.getName());
 
     /**
      * The type of this Dynamic Programming problem, which must be assigned when instantiating a
@@ -296,7 +296,7 @@ public abstract class Problem extends TitledModel {
         int size = executionHistory.size();
 
         if (size == 0) {
-            Problem.LOGGER.log(Level.WARNING, "Cannot undo past Line 0");
+            Problem.julLogger.log(Level.WARNING, "Cannot undo past Line 0");
 
         } else {
             int lastItemPos = size - 1;
@@ -341,15 +341,15 @@ public abstract class Problem extends TitledModel {
             method.invoke(this);
 
         } catch (NoSuchMethodException ex) {
-            Problem.LOGGER.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(Level.SEVERE, null, ex);
         } catch (SecurityException ex) {
-            Problem.LOGGER.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(Level.SEVERE, null, ex);
         } catch (IllegalAccessException ex) {
-            Problem.LOGGER.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(Level.SEVERE, null, ex);
         } catch (IllegalArgumentException ex) {
-            Problem.LOGGER.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(Level.SEVERE, null, ex);
         } catch (InvocationTargetException ex) {
-            Problem.LOGGER.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(Level.SEVERE, null, ex);
         }
     }
 

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -40,7 +40,7 @@ public abstract class Problem extends TitledModel {
     private static final int RUN_STEP_INTERVAL = 500;
 
     /** The logger for the class */
-    private static final Logger julLogger = Logger.getLogger(Problem.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(Problem.class.getName());
 
     /**
      * The type of this Dynamic Programming problem, which must be assigned when instantiating a

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -12,15 +12,15 @@
  */
 package edu.regis.dptu.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Dynamic Programming problem that a student is attempting to solve.
@@ -36,7 +36,6 @@ import java.util.logging.Logger;
  */
 public abstract class Problem extends TitledModel {
     private static final Logger log = LoggerFactory.getLogger(Problem.class);
-
 
     /** The time between steps when running all */
     private static final int RUN_STEP_INTERVAL = 500;

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -16,7 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -297,7 +297,7 @@ public abstract class Problem extends TitledModel {
         int size = executionHistory.size();
 
         if (size == 0) {
-            Problem.julLogger.log(Level.WARNING, "Cannot undo past Line 0");
+            Problem.julLogger.log(java.util.logging.Level.WARNING, "Cannot undo past Line 0");
 
         } else {
             int lastItemPos = size - 1;
@@ -342,15 +342,15 @@ public abstract class Problem extends TitledModel {
             method.invoke(this);
 
         } catch (NoSuchMethodException ex) {
-            Problem.julLogger.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
         } catch (SecurityException ex) {
-            Problem.julLogger.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
         } catch (IllegalAccessException ex) {
-            Problem.julLogger.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
         } catch (IllegalArgumentException ex) {
-            Problem.julLogger.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
         } catch (InvocationTargetException ex) {
-            Problem.julLogger.log(Level.SEVERE, null, ex);
+            Problem.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
         }
     }
 

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -32,6 +35,8 @@ import java.util.logging.Logger;
  * @author rickb
  */
 public abstract class Problem extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(Problem.class);
+
 
     /** The time between steps when running all */
     private static final int RUN_STEP_INTERVAL = 500;

--- a/src/main/java/edu/regis/dptu/model/StepCompletion.java
+++ b/src/main/java/edu/regis/dptu/model/StepCompletion.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Represents a step that the student completed.
  *
  * @author rickb
  */
 public class StepCompletion {
+    private static final Logger log = LoggerFactory.getLogger(StepCompletion.class);
+
     /** The step that was completed. */
     private Step step;
 

--- a/src/main/java/edu/regis/dptu/model/StepCompletionReply.java
+++ b/src/main/java/edu/regis/dptu/model/StepCompletionReply.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Captures the tutor's reply to a previous step completed requests.
  *
  * @author rickb
  */
 public class StepCompletionReply {
+    private static final Logger log = LoggerFactory.getLogger(StepCompletionReply.class);
+
     /** Was the student's submitted answer correct. */
     private boolean isCorrect;
 

--- a/src/main/java/edu/regis/dptu/model/Student.java
+++ b/src/main/java/edu/regis/dptu/model/Student.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.aol.StudentModel;
 
 /**
@@ -21,6 +24,8 @@ import edu.regis.dptu.model.aol.StudentModel;
  * @author rickb
  */
 public class Student {
+    private static final Logger log = LoggerFactory.getLogger(Student.class);
+
     /** The account associated with this student. */
     private final Account account;
 

--- a/src/main/java/edu/regis/dptu/model/Task.java
+++ b/src/main/java/edu/regis/dptu/model/Task.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
 /**
@@ -26,6 +29,8 @@ import java.util.ArrayList;
  * @author rickb
  */
 public class Task extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(Task.class);
+
     /** Indicates the type of task the student trying to complete. */
     private TaskKind kind = TaskKind.PROBLEM;
 

--- a/src/main/java/edu/regis/dptu/model/Task.java
+++ b/src/main/java/edu/regis/dptu/model/Task.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 
 /**
  * A multi-minute activity that can be skipped or interchanged with other tasks, whose steps the

--- a/src/main/java/edu/regis/dptu/model/TaskState.java
+++ b/src/main/java/edu/regis/dptu/model/TaskState.java
@@ -12,11 +12,11 @@
  */
 package edu.regis.dptu.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashMap;
 import java.util.LinkedList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * To provide appropriate hints to the student, we need to keep track of what task steps they've

--- a/src/main/java/edu/regis/dptu/model/TaskState.java
+++ b/src/main/java/edu/regis/dptu/model/TaskState.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 
@@ -22,6 +25,8 @@ import java.util.LinkedList;
  * @author rickb
  */
 public class TaskState {
+    private static final Logger log = LoggerFactory.getLogger(TaskState.class);
+
     /** The sequence id, zero-indexed, of the currently expected task. */
     private int currentTask = 0;
 

--- a/src/main/java/edu/regis/dptu/model/Timeout.java
+++ b/src/main/java/edu/regis/dptu/model/Timeout.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A timeout starts a clock ticking and performs the associated event, if the expected action, task,
  * or step containing the timeout isn't performed.
@@ -22,6 +25,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class Timeout {
+    private static final Logger log = LoggerFactory.getLogger(Timeout.class);
+
     /** The type of action that initialized this timeout. */
     protected final String type;
 

--- a/src/main/java/edu/regis/dptu/model/TitledModel.java
+++ b/src/main/java/edu/regis/dptu/model/TitledModel.java
@@ -12,12 +12,17 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A model with a title and description.
  *
  * @author rickb
  */
 public abstract class TitledModel extends Model {
+    private static final Logger log = LoggerFactory.getLogger(TitledModel.class);
+
     /** The title or name of this model, which can be displayed to the user. */
     protected String title;
 

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -12,11 +12,11 @@
  */
 package edu.regis.dptu.model;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Dynamic Programming tutoring session, which is displayed in the tutor view.

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.GregorianCalendar;
 
@@ -21,6 +24,8 @@ import java.util.GregorianCalendar;
  * @author rickb
  */
 public class TutoringSession {
+    private static final Logger log = LoggerFactory.getLogger(TutoringSession.class);
+
     /** The id of this session in the database. */
     private int id;
 

--- a/src/main/java/edu/regis/dptu/model/Unit.java
+++ b/src/main/java/edu/regis/dptu/model/Unit.java
@@ -12,10 +12,10 @@
  */
 package edu.regis.dptu.model;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 
 /**
  * A semantically cohesive collection of tasks within a course that a student is expected to master

--- a/src/main/java/edu/regis/dptu/model/Unit.java
+++ b/src/main/java/edu/regis/dptu/model/Unit.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 
 /**
@@ -21,6 +24,8 @@ import java.util.ArrayList;
  * @author rickb
  */
 public class Unit extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(Unit.class);
+
     /** The pedagogical approach used to select the next task within this unit. */
     private TaskSelectionKind pedagogy;
 

--- a/src/main/java/edu/regis/dptu/model/UnitDigest.java
+++ b/src/main/java/edu/regis/dptu/model/UnitDigest.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A descriptive summary of a unit as used in a tutoring session, which eliminates the need to
  * return an entire unit to the GUI.
@@ -19,6 +22,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class UnitDigest extends TitledModel {
+    private static final Logger log = LoggerFactory.getLogger(UnitDigest.class);
+
     /** The courseId to which the unit belongs. */
     private int courseId;
 

--- a/src/main/java/edu/regis/dptu/model/User.java
+++ b/src/main/java/edu/regis/dptu/model/User.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A user with sign-in credentials consisting of a user id and password.
  *
@@ -20,6 +23,8 @@ package edu.regis.dptu.model;
  * @author rickb
  */
 public class User extends Model {
+    private static final Logger log = LoggerFactory.getLogger(User.class);
+
     /** The user's login id (e.g. "name@university.edu"). */
     protected String userId;
 

--- a/src/main/java/edu/regis/dptu/model/Variable.java
+++ b/src/main/java/edu/regis/dptu/model/Variable.java
@@ -12,10 +12,15 @@
  */
 package edu.regis.dptu.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author rickb
  */
 public class Variable {
+    private static final Logger log = LoggerFactory.getLogger(Variable.class);
+
     private String name;
 
     private DataType dataType;

--- a/src/main/java/edu/regis/dptu/model/aol/Assessment.java
+++ b/src/main/java/edu/regis/dptu/model/aol/Assessment.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model.aol;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.KnowledgeComponent;
 import edu.regis.dptu.model.Model;
 
@@ -21,6 +24,8 @@ import edu.regis.dptu.model.Model;
  * @author rickb
  */
 public class Assessment extends Model {
+    private static final Logger log = LoggerFactory.getLogger(Assessment.class);
+
     /** The knowledge component assessed in this assessment */
     private KnowledgeComponent outcome;
 

--- a/src/main/java/edu/regis/dptu/model/aol/StudentModel.java
+++ b/src/main/java/edu/regis/dptu/model/aol/StudentModel.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.model.aol;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +29,8 @@ import edu.regis.dptu.model.TutoringSession;
  * @author rickb
  */
 public class StudentModel {
+    private static final Logger log = LoggerFactory.getLogger(StudentModel.class);
+
     /**
      * Convenience reference to the user id (email) of the student associated with this student
      * model.

--- a/src/main/java/edu/regis/dptu/model/aol/StudentModel.java
+++ b/src/main/java/edu/regis/dptu/model/aol/StudentModel.java
@@ -12,12 +12,12 @@
  */
 package edu.regis.dptu.model.aol;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.ScaffoldLevel;
 import edu.regis.dptu.model.TutoringSession;

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -37,7 +37,7 @@ public class DpTuServer implements Runnable {
     public static final int PORT = 53637;
 
     /** Handler for logging messages. */
-    private static final Logger julLogger = Logger.getLogger(DpTuServer.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuServer.class.getName());
 
     /** The socket listening for connections from the client */
     private ServerSocket server;

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -18,7 +18,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.logging.Level;
+
 
 import com.google.gson.Gson;
 
@@ -61,7 +61,7 @@ public class DpTuServer implements Runnable {
             }
 
         } catch (IOException e) {
-            julLogger.log(Level.SEVERE, "EncryptionServer.run()", e);
+            julLogger.log(java.util.logging.Level.SEVERE, "EncryptionServer.run()", e);
         }
     }
 
@@ -111,7 +111,7 @@ public class DpTuServer implements Runnable {
                 out.flush();
 
             } catch (IOException e) {
-                julLogger.log(Level.SEVERE, "EncryptionConnection.run()", e);
+                julLogger.log(java.util.logging.Level.SEVERE, "EncryptionConnection.run()", e);
             } finally {
                 // About as ugly as it gets, but the following code ensures that
                 // we've at least tried to close an open socket and its associated
@@ -127,14 +127,14 @@ public class DpTuServer implements Runnable {
                             in.close();
                         }
                     } catch (IOException e) {
-                        julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
                     } finally {
                         try {
                             if (client != null) {
                                 client.close();
                             }
                         } catch (IOException e) {
-                            julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
+                            julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
                         }
                     }
                 }

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -20,7 +20,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.logging.Level;
 
-
 import com.google.gson.Gson;
 
 /**

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -19,7 +19,7 @@ import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import com.google.gson.Gson;
 

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -19,7 +19,6 @@ import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 
-
 import com.google.gson.Gson;
 
 /**
@@ -127,14 +126,20 @@ public class DpTuServer implements Runnable {
                             in.close();
                         }
                     } catch (IOException e) {
-                        julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(
+                                java.util.logging.Level.SEVERE,
+                                "Unable to close client socket in",
+                                e);
                     } finally {
                         try {
                             if (client != null) {
                                 client.close();
                             }
                         } catch (IOException e) {
-                            julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
+                            julLogger.log(
+                                    java.util.logging.Level.SEVERE,
+                                    "Unable to close client socket in",
+                                    e);
                         }
                     }
                 }

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -37,7 +37,8 @@ public class DpTuServer implements Runnable {
     public static final int PORT = 53637;
 
     /** Handler for logging messages. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuServer.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(DpTuServer.class.getName());
 
     /** The socket listening for connections from the client */
     private ServerSocket server;

--- a/src/main/java/edu/regis/dptu/svc/DpTuServer.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuServer.java
@@ -37,7 +37,7 @@ public class DpTuServer implements Runnable {
     public static final int PORT = 53637;
 
     /** Handler for logging messages. */
-    private static final Logger LOGGER = Logger.getLogger(DpTuServer.class.getName());
+    private static final Logger julLogger = Logger.getLogger(DpTuServer.class.getName());
 
     /** The socket listening for connections from the client */
     private ServerSocket server;
@@ -60,7 +60,7 @@ public class DpTuServer implements Runnable {
             }
 
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "EncryptionServer.run()", e);
+            julLogger.log(Level.SEVERE, "EncryptionServer.run()", e);
         }
     }
 
@@ -110,7 +110,7 @@ public class DpTuServer implements Runnable {
                 out.flush();
 
             } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "EncryptionConnection.run()", e);
+                julLogger.log(Level.SEVERE, "EncryptionConnection.run()", e);
             } finally {
                 // About as ugly as it gets, but the following code ensures that
                 // we've at least tried to close an open socket and its associated
@@ -126,14 +126,14 @@ public class DpTuServer implements Runnable {
                             in.close();
                         }
                     } catch (IOException e) {
-                        LOGGER.log(Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
                     } finally {
                         try {
                             if (client != null) {
                                 client.close();
                             }
                         } catch (IOException e) {
-                            LOGGER.log(Level.SEVERE, "Unable to close client socket in", e);
+                            julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
                         }
                     }
                 }

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -12,15 +12,15 @@
  */
 package edu.regis.dptu.svc;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
 import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,7 +53,6 @@ import edu.regis.dptu.util.SHA_256;
  */
 public class DpTuTutor implements TutorSvc {
     private static final Logger log = LoggerFactory.getLogger(DpTuTutor.class);
-
 
     /** The id of the default course taught by the this tutor (Dynamic Programming). */
     private static final int DEFAULT_COURSE_ID = 1;

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
 import java.util.Random;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
 import java.util.Random;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +81,8 @@ public class DpTuTutor implements TutorSvc {
     public TutorReply request(ClientRequest request) {
         // Uses reflection to invoke a method derived from the request name in
         // the client request (e.g., ":SignIn" invokes "signIn(...)").
-        DpTuTutor.julLogger.log(java.util.logging.Level.INFO, request.getRequestType().getRequestName());
+        DpTuTutor.julLogger.log(
+                java.util.logging.Level.INFO, request.getRequestType().getRequestName());
 
         // Efficiently produce "signIn" from ":SignIn", for example.
         char c[] = request.getRequestType().getRequestName().toCharArray();
@@ -136,7 +136,8 @@ public class DpTuTutor implements TutorSvc {
                 break;
 
             default: // e.g., signIn itself, newAccount
-                DpTuTutor.julLogger.log(java.util.logging.Level.INFO, "No token verification required");
+                DpTuTutor.julLogger.log(
+                        java.util.logging.Level.INFO, "No token verification required");
         }
 
         // Security token has been verified or not required (e.g., signIn, createAccount).

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -60,7 +60,8 @@ public class DpTuTutor implements TutorSvc {
      * Handler for logging non-exception messages from this class versus thrown exception, which are
      * logged by the exception.
      */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuTutor.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(DpTuTutor.class.getName());
 
     /** Convenience reference to the student currently being tutored. */
     private Student student;

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -18,7 +18,6 @@ import java.util.GregorianCalendar;
 import java.util.Random;
 import java.util.logging.Level;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -16,7 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
 import java.util.Random;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +82,7 @@ public class DpTuTutor implements TutorSvc {
     public TutorReply request(ClientRequest request) {
         // Uses reflection to invoke a method derived from the request name in
         // the client request (e.g., ":SignIn" invokes "signIn(...)").
-        DpTuTutor.julLogger.log(Level.INFO, request.getRequestType().getRequestName());
+        DpTuTutor.julLogger.log(java.util.logging.Level.INFO, request.getRequestType().getRequestName());
 
         // Efficiently produce "signIn" from ":SignIn", for example.
         char c[] = request.getRequestType().getRequestName().toCharArray();
@@ -132,11 +132,11 @@ public class DpTuTutor implements TutorSvc {
                 }
 
                 String msg = "Session verified for " + request.getUserId();
-                DpTuTutor.julLogger.log(Level.INFO, msg);
+                DpTuTutor.julLogger.log(java.util.logging.Level.INFO, msg);
                 break;
 
             default: // e.g., signIn itself, newAccount
-                DpTuTutor.julLogger.log(Level.INFO, "No token verification required");
+                DpTuTutor.julLogger.log(java.util.logging.Level.INFO, "No token verification required");
         }
 
         // Security token has been verified or not required (e.g., signIn, createAccount).
@@ -242,7 +242,7 @@ public class DpTuTutor implements TutorSvc {
         } catch (ObjNotFoundException e) {
             return new TutorReply("UnknownUser");
         } catch (NonRecoverableException ex) {
-            DpTuTutor.julLogger.log(Level.SEVERE, null, ex);
+            DpTuTutor.julLogger.log(java.util.logging.Level.SEVERE, null, ex);
             return new TutorReply();
         }
     }
@@ -474,9 +474,9 @@ public class DpTuTutor implements TutorSvc {
      */
     private TutorReply createError(String errMsg, Exception ex) {
         if (ex == null) {
-            DpTuTutor.julLogger.log(Level.SEVERE, errMsg);
+            DpTuTutor.julLogger.log(java.util.logging.Level.SEVERE, errMsg);
         } else {
-            DpTuTutor.julLogger.log(Level.SEVERE, errMsg, ex);
+            DpTuTutor.julLogger.log(java.util.logging.Level.SEVERE, errMsg, ex);
         }
 
         return new TutorReply(":ERR", errMsg);

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -60,7 +60,7 @@ public class DpTuTutor implements TutorSvc {
      * Handler for logging non-exception messages from this class versus thrown exception, which are
      * logged by the exception.
      */
-    private static final Logger julLogger = Logger.getLogger(DpTuTutor.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DpTuTutor.class.getName());
 
     /** Convenience reference to the student currently being tutored. */
     private Student student;

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.svc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
@@ -49,6 +52,8 @@ import edu.regis.dptu.util.SHA_256;
  * @author rickb
  */
 public class DpTuTutor implements TutorSvc {
+    private static final Logger log = LoggerFactory.getLogger(DpTuTutor.class);
+
 
     /** The id of the default course taught by the this tutor (Dynamic Programming). */
     private static final int DEFAULT_COURSE_ID = 1;

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -60,7 +60,7 @@ public class DpTuTutor implements TutorSvc {
      * Handler for logging non-exception messages from this class versus thrown exception, which are
      * logged by the exception.
      */
-    private static final Logger LOGGER = Logger.getLogger(DpTuTutor.class.getName());
+    private static final Logger julLogger = Logger.getLogger(DpTuTutor.class.getName());
 
     /** Convenience reference to the student currently being tutored. */
     private Student student;
@@ -81,7 +81,7 @@ public class DpTuTutor implements TutorSvc {
     public TutorReply request(ClientRequest request) {
         // Uses reflection to invoke a method derived from the request name in
         // the client request (e.g., ":SignIn" invokes "signIn(...)").
-        DpTuTutor.LOGGER.log(Level.INFO, request.getRequestType().getRequestName());
+        DpTuTutor.julLogger.log(Level.INFO, request.getRequestType().getRequestName());
 
         // Efficiently produce "signIn" from ":SignIn", for example.
         char c[] = request.getRequestType().getRequestName().toCharArray();
@@ -131,11 +131,11 @@ public class DpTuTutor implements TutorSvc {
                 }
 
                 String msg = "Session verified for " + request.getUserId();
-                DpTuTutor.LOGGER.log(Level.INFO, msg);
+                DpTuTutor.julLogger.log(Level.INFO, msg);
                 break;
 
             default: // e.g., signIn itself, newAccount
-                DpTuTutor.LOGGER.log(Level.INFO, "No token verification required");
+                DpTuTutor.julLogger.log(Level.INFO, "No token verification required");
         }
 
         // Security token has been verified or not required (e.g., signIn, createAccount).
@@ -241,7 +241,7 @@ public class DpTuTutor implements TutorSvc {
         } catch (ObjNotFoundException e) {
             return new TutorReply("UnknownUser");
         } catch (NonRecoverableException ex) {
-            DpTuTutor.LOGGER.log(Level.SEVERE, null, ex);
+            DpTuTutor.julLogger.log(Level.SEVERE, null, ex);
             return new TutorReply();
         }
     }
@@ -473,9 +473,9 @@ public class DpTuTutor implements TutorSvc {
      */
     private TutorReply createError(String errMsg, Exception ex) {
         if (ex == null) {
-            DpTuTutor.LOGGER.log(Level.SEVERE, errMsg);
+            DpTuTutor.julLogger.log(Level.SEVERE, errMsg);
         } else {
-            DpTuTutor.LOGGER.log(Level.SEVERE, errMsg, ex);
+            DpTuTutor.julLogger.log(Level.SEVERE, errMsg, ex);
         }
 
         return new TutorReply(":ERR", errMsg);

--- a/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
+++ b/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.svc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.dao.AccountDAO;
 import edu.regis.dptu.dao.CourseDAO;
 import edu.regis.dptu.dao.ProblemDAO;
@@ -28,6 +31,8 @@ import edu.regis.dptu.dao.StudentModelDAO;
  * @author rickb
  */
 public class ServiceFactory {
+    private static final Logger log = LoggerFactory.getLogger(ServiceFactory.class);
+
     /**
      * Return a reference to a User service.
      *

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -18,7 +18,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.UnknownHostException;
-import java.util.logging.Level;
+
 
 import com.google.gson.Gson;
 
@@ -126,9 +126,9 @@ public class SvcFacade {
             return in.readLine();
 
         } catch (UnknownHostException e) {
-            julLogger.log(Level.SEVERE, "Unknown Host", e);
+            julLogger.log(java.util.logging.Level.SEVERE, "Unknown Host", e);
         } catch (IOException e) {
-            julLogger.log(Level.SEVERE, "IOException client", e);
+            julLogger.log(java.util.logging.Level.SEVERE, "IOException client", e);
         } finally {
             // Kludgy, but tries to close an open socket and its associated
             // input and output streams in every possible error scenario
@@ -139,12 +139,12 @@ public class SvcFacade {
                 try {
                     if (in != null) in.close();
                 } catch (IOException e) {
-                    julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
+                    julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
                 } finally {
                     try {
                         if (client != null) client.close();
                     } catch (IOException e) {
-                        julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
                     }
                 }
             }

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -65,7 +65,7 @@ public class SvcFacade {
     }
 
     /** Handler for logging messages. */
-    private static final Logger LOGGER = Logger.getLogger(SvcFacade.class.getName());
+    private static final Logger julLogger = Logger.getLogger(SvcFacade.class.getName());
 
     /**
      * The computer host to which DpTu tutor requests are delegated.
@@ -125,9 +125,9 @@ public class SvcFacade {
             return in.readLine();
 
         } catch (UnknownHostException e) {
-            LOGGER.log(Level.SEVERE, "Unknown Host", e);
+            julLogger.log(Level.SEVERE, "Unknown Host", e);
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "IOException client", e);
+            julLogger.log(Level.SEVERE, "IOException client", e);
         } finally {
             // Kludgy, but tries to close an open socket and its associated
             // input and output streams in every possible error scenario
@@ -138,12 +138,12 @@ public class SvcFacade {
                 try {
                     if (in != null) in.close();
                 } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE, "Unable to close client socket in", e);
+                    julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
                 } finally {
                     try {
                         if (client != null) client.close();
                     } catch (IOException e) {
-                        LOGGER.log(Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(Level.SEVERE, "Unable to close client socket in", e);
                     }
                 }
             }

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -65,7 +65,8 @@ public class SvcFacade {
     }
 
     /** Handler for logging messages. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(SvcFacade.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(SvcFacade.class.getName());
 
     /**
      * The computer host to which DpTu tutor requests are delegated.

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -20,7 +20,6 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.logging.Level;
 
-
 import com.google.gson.Gson;
 
 /**

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -19,7 +19,6 @@ import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
-
 import com.google.gson.Gson;
 
 /**
@@ -139,12 +138,16 @@ public class SvcFacade {
                 try {
                     if (in != null) in.close();
                 } catch (IOException e) {
-                    julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
+                    julLogger.log(
+                            java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
                 } finally {
                     try {
                         if (client != null) client.close();
                     } catch (IOException e) {
-                        julLogger.log(java.util.logging.Level.SEVERE, "Unable to close client socket in", e);
+                        julLogger.log(
+                                java.util.logging.Level.SEVERE,
+                                "Unable to close client socket in",
+                                e);
                     }
                 }
             }

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -19,7 +19,7 @@ import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import com.google.gson.Gson;
 

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -65,7 +65,7 @@ public class SvcFacade {
     }
 
     /** Handler for logging messages. */
-    private static final Logger julLogger = Logger.getLogger(SvcFacade.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(SvcFacade.class.getName());
 
     /**
      * The computer host to which DpTu tutor requests are delegated.

--- a/src/main/java/edu/regis/dptu/util/CustomProgressBar.java
+++ b/src/main/java/edu/regis/dptu/util/CustomProgressBar.java
@@ -5,6 +5,9 @@
  */
 package edu.regis.dptu.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -17,6 +20,8 @@ import java.awt.geom.RoundRectangle2D;
 import javax.swing.JProgressBar;
 
 public class CustomProgressBar extends JProgressBar {
+    private static final Logger log = LoggerFactory.getLogger(CustomProgressBar.class);
+
     private static final int ARC_WIDTH = 10;
     private static final int ARC_HEIGHT = 10;
     private Color progressColor = new Color(241, 196, 0);

--- a/src/main/java/edu/regis/dptu/util/CustomProgressBar.java
+++ b/src/main/java/edu/regis/dptu/util/CustomProgressBar.java
@@ -5,9 +5,6 @@
  */
 package edu.regis.dptu.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -18,6 +15,9 @@ import java.awt.geom.Point2D;
 import java.awt.geom.RoundRectangle2D;
 
 import javax.swing.JProgressBar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CustomProgressBar extends JProgressBar {
     private static final Logger log = LoggerFactory.getLogger(CustomProgressBar.class);

--- a/src/main/java/edu/regis/dptu/util/ImgFactory.java
+++ b/src/main/java/edu/regis/dptu/util/ImgFactory.java
@@ -12,14 +12,14 @@
  */
 package edu.regis.dptu.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides support for loading image icons from files on the CLASSPATH.

--- a/src/main/java/edu/regis/dptu/util/ImgFactory.java
+++ b/src/main/java/edu/regis/dptu/util/ImgFactory.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
@@ -24,6 +27,8 @@ import javax.swing.ImageIcon;
  * @author rickb
  */
 public class ImgFactory {
+    private static final Logger log = LoggerFactory.getLogger(ImgFactory.class);
+
     /** Directory in the Resource path where the images are located. */
     private static final String DIRECTORY = "/";
 

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -31,7 +31,7 @@ import edu.regis.dptu.err.MissingPropertyException;
  */
 public class ResourceMgr {
     /** Logger for any errors occurring in this Singleton. */
-    private static final Logger LOGGER = Logger.getLogger("ResourceMgr.class");
+    private static final Logger julLogger = Logger.getLogger("ResourceMgr.class");
 
     /** The singleton instance of this ResourceMgr. */
     private static final ResourceMgr SINGLETON;
@@ -97,7 +97,7 @@ public class ResourceMgr {
             msgs = ResourceBundle.getBundle(UI_RESOURCE_PATH, locale);
 
         } catch (MissingPropertyException e) {
-            LOGGER.log(Level.SEVERE, "Missing Property", e);
+            julLogger.log(Level.SEVERE, "Missing Property", e);
         }
     }
 
@@ -151,9 +151,9 @@ public class ResourceMgr {
             properties.load(strm);
 
         } catch (FileNotFoundException e) {
-            LOGGER.log(Level.ALL, "PropertyMgr-ERR_100: {0}", e.toString());
+            julLogger.log(Level.ALL, "PropertyMgr-ERR_100: {0}", e.toString());
         } catch (IOException e) {
-            LOGGER.log(Level.ALL, "PropertyMgr-ERR_101: {0}", e.toString());
+            julLogger.log(Level.ALL, "PropertyMgr-ERR_101: {0}", e.toString());
         }
     }
 }

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -31,7 +31,8 @@ import edu.regis.dptu.err.MissingPropertyException;
  */
 public class ResourceMgr {
     /** Logger for any errors occurring in this Singleton. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger("ResourceMgr.class");
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger("ResourceMgr.class");
 
     /** The singleton instance of this ResourceMgr. */
     private static final ResourceMgr SINGLETON;

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 
-
 import edu.regis.dptu.err.MissingPropertyException;
 
 /**

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -31,7 +31,7 @@ import edu.regis.dptu.err.MissingPropertyException;
  */
 public class ResourceMgr {
     /** Logger for any errors occurring in this Singleton. */
-    private static final Logger julLogger = Logger.getLogger("ResourceMgr.class");
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger("ResourceMgr.class");
 
     /** The singleton instance of this ResourceMgr. */
     private static final ResourceMgr SINGLETON;

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.ResourceBundle;
-import java.util.logging.Level;
+
 
 import edu.regis.dptu.err.MissingPropertyException;
 
@@ -98,7 +98,7 @@ public class ResourceMgr {
             msgs = ResourceBundle.getBundle(UI_RESOURCE_PATH, locale);
 
         } catch (MissingPropertyException e) {
-            julLogger.log(Level.SEVERE, "Missing Property", e);
+            julLogger.log(java.util.logging.Level.SEVERE, "Missing Property", e);
         }
     }
 
@@ -152,9 +152,9 @@ public class ResourceMgr {
             properties.load(strm);
 
         } catch (FileNotFoundException e) {
-            julLogger.log(Level.ALL, "PropertyMgr-ERR_100: {0}", e.toString());
+            julLogger.log(java.util.logging.Level.ALL, "PropertyMgr-ERR_100: {0}", e.toString());
         } catch (IOException e) {
-            julLogger.log(Level.ALL, "PropertyMgr-ERR_101: {0}", e.toString());
+            julLogger.log(java.util.logging.Level.ALL, "PropertyMgr-ERR_101: {0}", e.toString());
         }
     }
 }

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -19,7 +19,7 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import edu.regis.dptu.err.MissingPropertyException;
 

--- a/src/main/java/edu/regis/dptu/util/ResourceMgr.java
+++ b/src/main/java/edu/regis/dptu/util/ResourceMgr.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
-
 import edu.regis.dptu.err.MissingPropertyException;
 
 /**

--- a/src/main/java/edu/regis/dptu/util/SHA_256.java
+++ b/src/main/java/edu/regis/dptu/util/SHA_256.java
@@ -13,12 +13,12 @@
  */
 package edu.regis.dptu.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.charset.Charset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of the SHA-256 algorithm.

--- a/src/main/java/edu/regis/dptu/util/SHA_256.java
+++ b/src/main/java/edu/regis/dptu/util/SHA_256.java
@@ -13,6 +13,9 @@
  */
 package edu.regis.dptu.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.charset.Charset;
@@ -29,6 +32,8 @@ import java.nio.charset.Charset;
  * @author unknown
  */
 public class SHA_256 {
+    private static final Logger log = LoggerFactory.getLogger(SHA_256.class);
+
     /** The singleton instance of this frame. */
     private static final SHA_256 SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -25,7 +25,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -50,7 +50,7 @@ public class XmlMgr {
     private static final Logger log = LoggerFactory.getLogger(XmlMgr.class);
 
     /** Log unexpected events to this logger. */
-    private static final Logger julLogger = Logger.getLogger(XmlMgr.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(XmlMgr.class.getName());
 
     /** Data directory containing data files within the current NetBeans project. */
     private static final String DATA_DIRECTORY = "src/main/java/resources/Data/";

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
+
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -274,7 +274,7 @@ public class XmlMgr {
         NodeList nodes = root.getElementsByTagName(tag);
 
         if (nodes.getLength() == 0) {
-            julLogger.log(Level.ALL, "XmlMgr: Unknown tag: {0}", tag);
+            julLogger.log(java.util.logging.Level.ALL, "XmlMgr: Unknown tag: {0}", tag);
             return "";
         } else {
             Node node = nodes.item(0);
@@ -283,7 +283,7 @@ public class XmlMgr {
                 Element element = (Element) node;
                 return element.getTextContent();
             } else {
-                julLogger.log(Level.ALL, "XmlMgr: Unknown tag type: {1}", tag);
+                julLogger.log(java.util.logging.Level.ALL, "XmlMgr: Unknown tag type: {1}", tag);
                 return "";
             }
         }
@@ -312,7 +312,7 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals(""))
-            julLogger.log(Level.ALL, "Missing or empty attribute {0}", attributeName);
+            julLogger.log(java.util.logging.Level.ALL, "Missing or empty attribute {0}", attributeName);
 
         return val;
     }
@@ -340,13 +340,13 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            julLogger.log(Level.ALL, "Missing or empty int attribute {0}", attributeName);
+            julLogger.log(java.util.logging.Level.ALL, "Missing or empty int attribute {0}", attributeName);
             return -1;
         } else {
             try {
                 return Integer.parseInt(val);
             } catch (NumberFormatException e) {
-                julLogger.log(Level.ALL, "Expected an int attribute value: {1}", attributeName);
+                julLogger.log(java.util.logging.Level.ALL, "Expected an int attribute value: {1}", attributeName);
                 return -1;
             }
         }
@@ -363,14 +363,14 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            julLogger.log(Level.ALL, "Missing or empty float attribute {0}", attributeName);
+            julLogger.log(java.util.logging.Level.ALL, "Missing or empty float attribute {0}", attributeName);
             return 0.0f;
         } else {
             try {
                 return Float.parseFloat(val);
 
             } catch (NumberFormatException e) {
-                julLogger.log(Level.ALL, "Expected a float attribute value: {1}", attributeName);
+                julLogger.log(java.util.logging.Level.ALL, "Expected a float attribute value: {1}", attributeName);
                 return 0.0f;
             }
         }
@@ -389,7 +389,7 @@ public class XmlMgr {
 
         switch (val) {
             case "":
-                julLogger.log(Level.ALL, "Missing or empty boolean attribute {0}", attributeName);
+                julLogger.log(java.util.logging.Level.ALL, "Missing or empty boolean attribute {0}", attributeName);
                 return false;
             case "true":
             case "yes":
@@ -398,7 +398,7 @@ public class XmlMgr {
             case "no":
                 return false;
             default:
-                julLogger.log(Level.ALL, "Expected a boolean attribute value: {1}", attributeName);
+                julLogger.log(java.util.logging.Level.ALL, "Expected a boolean attribute value: {1}", attributeName);
                 return false;
         }
     }

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -12,9 +12,6 @@
  */
 package edu.regis.dptu.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -34,6 +31,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -25,7 +25,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -312,7 +311,8 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals(""))
-            julLogger.log(java.util.logging.Level.ALL, "Missing or empty attribute {0}", attributeName);
+            julLogger.log(
+                    java.util.logging.Level.ALL, "Missing or empty attribute {0}", attributeName);
 
         return val;
     }
@@ -340,13 +340,19 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            julLogger.log(java.util.logging.Level.ALL, "Missing or empty int attribute {0}", attributeName);
+            julLogger.log(
+                    java.util.logging.Level.ALL,
+                    "Missing or empty int attribute {0}",
+                    attributeName);
             return -1;
         } else {
             try {
                 return Integer.parseInt(val);
             } catch (NumberFormatException e) {
-                julLogger.log(java.util.logging.Level.ALL, "Expected an int attribute value: {1}", attributeName);
+                julLogger.log(
+                        java.util.logging.Level.ALL,
+                        "Expected an int attribute value: {1}",
+                        attributeName);
                 return -1;
             }
         }
@@ -363,14 +369,20 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            julLogger.log(java.util.logging.Level.ALL, "Missing or empty float attribute {0}", attributeName);
+            julLogger.log(
+                    java.util.logging.Level.ALL,
+                    "Missing or empty float attribute {0}",
+                    attributeName);
             return 0.0f;
         } else {
             try {
                 return Float.parseFloat(val);
 
             } catch (NumberFormatException e) {
-                julLogger.log(java.util.logging.Level.ALL, "Expected a float attribute value: {1}", attributeName);
+                julLogger.log(
+                        java.util.logging.Level.ALL,
+                        "Expected a float attribute value: {1}",
+                        attributeName);
                 return 0.0f;
             }
         }
@@ -389,7 +401,10 @@ public class XmlMgr {
 
         switch (val) {
             case "":
-                julLogger.log(java.util.logging.Level.ALL, "Missing or empty boolean attribute {0}", attributeName);
+                julLogger.log(
+                        java.util.logging.Level.ALL,
+                        "Missing or empty boolean attribute {0}",
+                        attributeName);
                 return false;
             case "true":
             case "yes":
@@ -398,7 +413,10 @@ public class XmlMgr {
             case "no":
                 return false;
             default:
-                julLogger.log(java.util.logging.Level.ALL, "Expected a boolean attribute value: {1}", attributeName);
+                julLogger.log(
+                        java.util.logging.Level.ALL,
+                        "Expected a boolean attribute value: {1}",
+                        attributeName);
                 return false;
         }
     }

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -310,7 +310,8 @@ public class XmlMgr {
     public static String getAttribute(Element element, String attributeName) {
         String val = element.getAttribute(attributeName);
 
-        if (val.equals("")) julLogger.log(Level.ALL, "Missing or empty attribute {0}", attributeName);
+        if (val.equals(""))
+            julLogger.log(Level.ALL, "Missing or empty attribute {0}", attributeName);
 
         return val;
     }

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -12,6 +12,9 @@
  */
 package edu.regis.dptu.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -46,6 +49,8 @@ import edu.regis.dptu.err.XmlException;
  * @author rickb
  */
 public class XmlMgr {
+    private static final Logger log = LoggerFactory.getLogger(XmlMgr.class);
+
     /** Log unexpected events to this logger. */
     private static final Logger LOGGER = Logger.getLogger(XmlMgr.class.getName());
 

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -50,7 +50,8 @@ public class XmlMgr {
     private static final Logger log = LoggerFactory.getLogger(XmlMgr.class);
 
     /** Log unexpected events to this logger. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(XmlMgr.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(XmlMgr.class.getName());
 
     /** Data directory containing data files within the current NetBeans project. */
     private static final String DATA_DIRECTORY = "src/main/java/resources/Data/";

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -50,7 +50,7 @@ public class XmlMgr {
     private static final Logger log = LoggerFactory.getLogger(XmlMgr.class);
 
     /** Log unexpected events to this logger. */
-    private static final Logger LOGGER = Logger.getLogger(XmlMgr.class.getName());
+    private static final Logger julLogger = Logger.getLogger(XmlMgr.class.getName());
 
     /** Data directory containing data files within the current NetBeans project. */
     private static final String DATA_DIRECTORY = "src/main/java/resources/Data/";
@@ -273,7 +273,7 @@ public class XmlMgr {
         NodeList nodes = root.getElementsByTagName(tag);
 
         if (nodes.getLength() == 0) {
-            LOGGER.log(Level.ALL, "XmlMgr: Unknown tag: {0}", tag);
+            julLogger.log(Level.ALL, "XmlMgr: Unknown tag: {0}", tag);
             return "";
         } else {
             Node node = nodes.item(0);
@@ -282,7 +282,7 @@ public class XmlMgr {
                 Element element = (Element) node;
                 return element.getTextContent();
             } else {
-                LOGGER.log(Level.ALL, "XmlMgr: Unknown tag type: {1}", tag);
+                julLogger.log(Level.ALL, "XmlMgr: Unknown tag type: {1}", tag);
                 return "";
             }
         }
@@ -310,7 +310,7 @@ public class XmlMgr {
     public static String getAttribute(Element element, String attributeName) {
         String val = element.getAttribute(attributeName);
 
-        if (val.equals("")) LOGGER.log(Level.ALL, "Missing or empty attribute {0}", attributeName);
+        if (val.equals("")) julLogger.log(Level.ALL, "Missing or empty attribute {0}", attributeName);
 
         return val;
     }
@@ -338,13 +338,13 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            LOGGER.log(Level.ALL, "Missing or empty int attribute {0}", attributeName);
+            julLogger.log(Level.ALL, "Missing or empty int attribute {0}", attributeName);
             return -1;
         } else {
             try {
                 return Integer.parseInt(val);
             } catch (NumberFormatException e) {
-                LOGGER.log(Level.ALL, "Expected an int attribute value: {1}", attributeName);
+                julLogger.log(Level.ALL, "Expected an int attribute value: {1}", attributeName);
                 return -1;
             }
         }
@@ -361,14 +361,14 @@ public class XmlMgr {
         String val = element.getAttribute(attributeName);
 
         if (val.equals("")) {
-            LOGGER.log(Level.ALL, "Missing or empty float attribute {0}", attributeName);
+            julLogger.log(Level.ALL, "Missing or empty float attribute {0}", attributeName);
             return 0.0f;
         } else {
             try {
                 return Float.parseFloat(val);
 
             } catch (NumberFormatException e) {
-                LOGGER.log(Level.ALL, "Expected a float attribute value: {1}", attributeName);
+                julLogger.log(Level.ALL, "Expected a float attribute value: {1}", attributeName);
                 return 0.0f;
             }
         }
@@ -387,7 +387,7 @@ public class XmlMgr {
 
         switch (val) {
             case "":
-                LOGGER.log(Level.ALL, "Missing or empty boolean attribute {0}", attributeName);
+                julLogger.log(Level.ALL, "Missing or empty boolean attribute {0}", attributeName);
                 return false;
             case "true":
             case "yes":
@@ -396,7 +396,7 @@ public class XmlMgr {
             case "no":
                 return false;
             default:
-                LOGGER.log(Level.ALL, "Expected a boolean attribute value: {1}", attributeName);
+                julLogger.log(Level.ALL, "Expected a boolean attribute value: {1}", attributeName);
                 return false;
         }
     }

--- a/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
+++ b/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
@@ -12,14 +12,15 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.util.ArrayList;
 
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;

--- a/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
+++ b/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.util.ArrayList;
 
@@ -26,6 +28,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author Gary
  */
 public class BacktrackingCodeView extends GPanel implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(BacktrackingCodeView.class);
+
     /**
      * Declares the BacktrackingCodeView model (a Problem object) displayed in this view along with
      * the necessary arrayLists for the code statements.

--- a/src/main/java/edu/regis/dptu/view/CodeView.java
+++ b/src/main/java/edu/regis/dptu/view/CodeView.java
@@ -12,15 +12,15 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;// import edu.regis.dptu.model.LCSProblem; // Keep import if needed, though model is passed in
 import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.util.ArrayList;
 
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
@@ -33,7 +33,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 public class CodeView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(CodeView.class);
-
 
     /**
      * Declares the CodeView model (a Problem object) displayed in this view along with the

--- a/src/main/java/edu/regis/dptu/view/CodeView.java
+++ b/src/main/java/edu/regis/dptu/view/CodeView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-// import edu.regis.dptu.model.LCSProblem; // Keep import if needed, though model is passed in
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;// import edu.regis.dptu.model.LCSProblem; // Keep import if needed, though model is passed in
 import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.util.ArrayList;
@@ -30,6 +32,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author cadencea
  */
 public class CodeView extends GPanel implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(CodeView.class);
+
 
     /**
      * Declares the CodeView model (a Problem object) displayed in this view along with the

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -9,7 +9,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridLayout;
 import java.util.Arrays;
-import java.util.logging.Level;
+
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -228,7 +228,7 @@ public class DashboardPanel extends GPanel {
         // Gracefully handle if the model objects don't exist.
         if (model == null || model.getStudent() == null) {
             julLogger.log(
-                    Level.WARNING,
+                    java.util.logging.Level.WARNING,
                     "DashboardPanel: model or student is null, " + "skipping scaffold level rules");
             return;
         }
@@ -236,7 +236,7 @@ public class DashboardPanel extends GPanel {
         // Get the current scaffold level.
         var studentModel = model.getStudent().getStudentModel();
         ScaffoldLevel lvl = studentModel.getScaffoldLevel();
-        julLogger.log(Level.INFO, "DashboardPanel: applying scaffold level rules for {0}", lvl);
+        julLogger.log(java.util.logging.Level.INFO, "DashboardPanel: applying scaffold level rules for {0}", lvl);
 
         // Create button enabled booleans.
         boolean seeOneButtonEnabled = false,

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -50,7 +50,8 @@ public class DashboardPanel extends GPanel {
     private static final Color REGIS_BLUE = new Color(0, 43, 73);
     private static final Color REGIS_GOLD = new Color(241, 196, 0);
 
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DashboardPanel.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(DashboardPanel.class.getName());
 
     public DashboardPanel(TutoringSession tutoringSession) {
         model = tutoringSession;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -11,7 +11,6 @@ import java.awt.GridLayout;
 import java.util.Arrays;
 import java.util.logging.Level;
 
-
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -10,7 +10,6 @@ import java.awt.Font;
 import java.awt.GridLayout;
 import java.util.Arrays;
 
-
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -236,7 +235,10 @@ public class DashboardPanel extends GPanel {
         // Get the current scaffold level.
         var studentModel = model.getStudent().getStudentModel();
         ScaffoldLevel lvl = studentModel.getScaffoldLevel();
-        julLogger.log(java.util.logging.Level.INFO, "DashboardPanel: applying scaffold level rules for {0}", lvl);
+        julLogger.log(
+                java.util.logging.Level.INFO,
+                "DashboardPanel: applying scaffold level rules for {0}",
+                lvl);
 
         // Create button enabled booleans.
         boolean seeOneButtonEnabled = false,

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -50,7 +50,7 @@ public class DashboardPanel extends GPanel {
     private static final Color REGIS_BLUE = new Color(0, 43, 73);
     private static final Color REGIS_GOLD = new Color(241, 196, 0);
 
-    private static final Logger julLogger = Logger.getLogger(DashboardPanel.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(DashboardPanel.class.getName());
 
     public DashboardPanel(TutoringSession tutoringSession) {
         model = tutoringSession;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -50,7 +50,7 @@ public class DashboardPanel extends GPanel {
     private static final Color REGIS_BLUE = new Color(0, 43, 73);
     private static final Color REGIS_GOLD = new Color(241, 196, 0);
 
-    private static final Logger LOGGER = Logger.getLogger(DashboardPanel.class.getName());
+    private static final Logger julLogger = Logger.getLogger(DashboardPanel.class.getName());
 
     public DashboardPanel(TutoringSession tutoringSession) {
         model = tutoringSession;
@@ -226,7 +226,7 @@ public class DashboardPanel extends GPanel {
 
         // Gracefully handle if the model objects don't exist.
         if (model == null || model.getStudent() == null) {
-            LOGGER.log(
+            julLogger.log(
                     Level.WARNING,
                     "DashboardPanel: model or student is null, " + "skipping scaffold level rules");
             return;
@@ -235,7 +235,7 @@ public class DashboardPanel extends GPanel {
         // Get the current scaffold level.
         var studentModel = model.getStudent().getStudentModel();
         ScaffoldLevel lvl = studentModel.getScaffoldLevel();
-        LOGGER.log(Level.INFO, "DashboardPanel: applying scaffold level rules for {0}", lvl);
+        julLogger.log(Level.INFO, "DashboardPanel: applying scaffold level rules for {0}", lvl);
 
         // Create button enabled booleans.
         boolean seeOneButtonEnabled = false,

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -3,9 +3,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -22,6 +20,9 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.ScaffoldLevel;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -10,7 +10,7 @@ import java.awt.Font;
 import java.awt.GridLayout;
 import java.util.Arrays;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -3,7 +3,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.BorderLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -30,6 +32,8 @@ import edu.regis.dptu.view.act.SeeOneAction;
 import edu.regis.dptu.view.act.TeachOneAction;
 
 public class DashboardPanel extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(DashboardPanel.class);
+
     private TutoringSession model;
 
     private JButton logOutButton;

--- a/src/main/java/edu/regis/dptu/view/DpTuMenuBar.java
+++ b/src/main/java/edu/regis/dptu/view/DpTuMenuBar.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import javax.swing.JMenu;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 
@@ -24,6 +26,8 @@ import edu.regis.dptu.view.act.SaveSessionAction;
  * @author rickb
  */
 public class DpTuMenuBar extends JMenuBar {
+    private static final Logger log = LoggerFactory.getLogger(DpTuMenuBar.class);
+
     /**
      * Constructor for the DpTuMenuBar class. Initializes the menu bar by creating the File menu.
      */

--- a/src/main/java/edu/regis/dptu/view/DpTuMenuBar.java
+++ b/src/main/java/edu/regis/dptu/view/DpTuMenuBar.java
@@ -12,11 +12,12 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import javax.swing.JMenu;
+import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.act.SaveSessionAction;
 

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -13,14 +13,15 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Component;
+import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
 import javax.swing.JPanel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility JPanel with a GridBagLayout and a convenience addc method.

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -13,7 +13,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Component;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -28,6 +30,8 @@ import javax.swing.JPanel;
  * @author rickb
  */
 public class GPanel extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(GPanel.class);
+
     /** Initialize this panel with a GridBagLayout. */
     public GPanel() {
         setLayout(new GridBagLayout());

--- a/src/main/java/edu/regis/dptu/view/HintTextField.java
+++ b/src/main/java/edu/regis/dptu/view/HintTextField.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
@@ -24,6 +22,9 @@ import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DocumentFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A JTextField with default text appearing in grey that disappears when a user enters anything, but

--- a/src/main/java/edu/regis/dptu/view/HintTextField.java
+++ b/src/main/java/edu/regis/dptu/view/HintTextField.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
@@ -35,6 +37,8 @@ import javax.swing.text.DocumentFilter;
  * @author rickb
  */
 public class HintTextField extends JTextField {
+    private static final Logger log = LoggerFactory.getLogger(HintTextField.class);
+
     /** The initial default 'hint' displayed as gray text in the field. */
     protected String hint = "";
 

--- a/src/main/java/edu/regis/dptu/view/KnapsackInputView.java
+++ b/src/main/java/edu/regis/dptu/view/KnapsackInputView.java
@@ -1,8 +1,6 @@
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
+import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
@@ -10,6 +8,9 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Currently, KnapsackInputView is thought to be designed as a Single Input field with an Add button

--- a/src/main/java/edu/regis/dptu/view/KnapsackInputView.java
+++ b/src/main/java/edu/regis/dptu/view/KnapsackInputView.java
@@ -1,6 +1,8 @@
 package edu.regis.dptu.view;
 
-import java.awt.GridBagConstraints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
@@ -19,6 +21,8 @@ import javax.swing.JTextField;
  * LCSInputView.java
  */
 public class KnapsackInputView extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(KnapsackInputView.class);
+
     public KnapsackInputView() {
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -28,7 +28,8 @@ public class LCSInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(LCSInputView.class);
 
     /** The logger for the class */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(LCSInputView.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(LCSInputView.class.getName());
 
     private ProblemListener submitListener;
 

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -1,8 +1,6 @@
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
+import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -15,6 +13,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -26,7 +27,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 public class LCSInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(LCSInputView.class);
-
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(LCSInputView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -6,7 +6,6 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -6,7 +6,7 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import javax.swing.JButton;
 import javax.swing.JLabel;

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -28,7 +28,7 @@ public class LCSInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(LCSInputView.class);
 
     /** The logger for the class */
-    private static final Logger LOGGER = Logger.getLogger(LCSInputView.class.getName());
+    private static final Logger julLogger = Logger.getLogger(LCSInputView.class.getName());
 
     private ProblemListener submitListener;
 
@@ -92,8 +92,8 @@ public class LCSInputView extends JPanel {
         string1 = string1.replaceAll("\\s", "");
         string2 = string2.replaceAll("\\s", "");
 
-        LCSInputView.LOGGER.log(Level.INFO, "Submitted String 1: " + string1);
-        LCSInputView.LOGGER.log(Level.INFO, "Submitted String 2: " + string2);
+        LCSInputView.julLogger.log(Level.INFO, "Submitted String 1: " + string1);
+        LCSInputView.julLogger.log(Level.INFO, "Submitted String 2: " + string2);
 
         LCSProblem newProblem = new LCSProblem(string1, string2);
         submitListener.problemUpdated(newProblem);

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -5,7 +5,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.logging.Level;
+
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -93,8 +93,8 @@ public class LCSInputView extends JPanel {
         string1 = string1.replaceAll("\\s", "");
         string2 = string2.replaceAll("\\s", "");
 
-        LCSInputView.julLogger.log(Level.INFO, "Submitted String 1: " + string1);
-        LCSInputView.julLogger.log(Level.INFO, "Submitted String 2: " + string2);
+        LCSInputView.julLogger.log(java.util.logging.Level.INFO, "Submitted String 1: " + string1);
+        LCSInputView.julLogger.log(java.util.logging.Level.INFO, "Submitted String 2: " + string2);
 
         LCSProblem newProblem = new LCSProblem(string1, string2);
         submitListener.problemUpdated(newProblem);

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -7,7 +7,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.logging.Level;
 
-
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -1,6 +1,8 @@
 package edu.regis.dptu.view;
 
-import java.awt.GridBagConstraints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -23,6 +25,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author EverettCV
  */
 public class LCSInputView extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(LCSInputView.class);
+
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(LCSInputView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/LCSInputView.java
+++ b/src/main/java/edu/regis/dptu/view/LCSInputView.java
@@ -28,7 +28,7 @@ public class LCSInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(LCSInputView.class);
 
     /** The logger for the class */
-    private static final Logger julLogger = Logger.getLogger(LCSInputView.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(LCSInputView.class.getName());
 
     private ProblemListener submitListener;
 

--- a/src/main/java/edu/regis/dptu/view/LessonSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/LessonSessionView.java
@@ -12,7 +12,11 @@
  */
 package edu.regis.dptu.view;
 
-/**
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;/**
  * @author hopea
  */
-class LessonSessionView {}
+class LessonSessionView {
+    private static final Logger log = LoggerFactory.getLogger(LessonSessionView.class);
+}

--- a/src/main/java/edu/regis/dptu/view/LessonSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/LessonSessionView.java
@@ -12,9 +12,10 @@
  */
 package edu.regis.dptu.view;
 
-
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;/**
+import org.slf4j.LoggerFactory;
+
+/**
  * @author hopea
  */
 class LessonSessionView {

--- a/src/main/java/edu/regis/dptu/view/MainFrame.java
+++ b/src/main/java/edu/regis/dptu/view/MainFrame.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Dimension;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
@@ -30,6 +32,8 @@ import edu.regis.dptu.view.act.ActionFactory;
  * @author rickb
  */
 public class MainFrame extends JFrame implements WindowListener {
+    private static final Logger log = LoggerFactory.getLogger(MainFrame.class);
+
     /** The singleton instance of this frame. */
     private static final MainFrame SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/MainFrame.java
+++ b/src/main/java/edu/regis/dptu/view/MainFrame.java
@@ -12,14 +12,15 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Dimension;
+import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 
 import javax.swing.JFrame;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.view.act.ActionFactory;

--- a/src/main/java/edu/regis/dptu/view/MatrixInputView.java
+++ b/src/main/java/edu/regis/dptu/view/MatrixInputView.java
@@ -1,8 +1,5 @@
 package edu.regis.dptu.view;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -11,6 +8,9 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Currently, MatrixInputView is thought to be designed as a single Matrix Input Field with an Add button to append

--- a/src/main/java/edu/regis/dptu/view/MatrixInputView.java
+++ b/src/main/java/edu/regis/dptu/view/MatrixInputView.java
@@ -1,5 +1,8 @@
 package edu.regis.dptu.view;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -18,6 +21,8 @@ import javax.swing.JTextField;
  * LCSInputView.java
  */
 public class MatrixInputView extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(MatrixInputView.class);
+
     public MatrixInputView() {
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -53,7 +53,7 @@ public class NewAccountPanel extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(NewAccountPanel.class);
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final Logger LOGGER = Logger.getLogger(NewAccountPanel.class.getName());
+    private static final Logger julLogger = Logger.getLogger(NewAccountPanel.class.getName());
 
     /** Events of interest occurring in this class are logged to this logger. */
 
@@ -974,7 +974,7 @@ public class NewAccountPanel extends GPanel {
             return String.format("%1$032X", i).toLowerCase();
 
         } catch (NoSuchAlgorithmException e) {
-            LOGGER.severe(e.toString());
+            julLogger.severe(e.toString());
         }
 
         return "";

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -39,6 +37,9 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.view.act.BackAction;
 import edu.regis.dptu.view.act.CreateAcctAction;
@@ -51,7 +52,6 @@ import edu.regis.dptu.view.act.SignInAction;
  */
 public class NewAccountPanel extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(NewAccountPanel.class);
-
 
     /** Events of interest occurring in this class are logged to this logger. */
     private static final Logger LOGGER = Logger.getLogger(NewAccountPanel.class.getName());

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -21,7 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.logging.Logger;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -21,7 +21,6 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -53,7 +53,7 @@ public class NewAccountPanel extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(NewAccountPanel.class);
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final Logger julLogger = Logger.getLogger(NewAccountPanel.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(NewAccountPanel.class.getName());
 
     /** Events of interest occurring in this class are logged to this logger. */
 

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -48,6 +50,8 @@ import edu.regis.dptu.view.act.SignInAction;
  * @author rickb
  */
 public class NewAccountPanel extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(NewAccountPanel.class);
+
 
     /** Events of interest occurring in this class are logged to this logger. */
     private static final Logger LOGGER = Logger.getLogger(NewAccountPanel.class.getName());

--- a/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
+++ b/src/main/java/edu/regis/dptu/view/NewAccountPanel.java
@@ -53,7 +53,8 @@ public class NewAccountPanel extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(NewAccountPanel.class);
 
     /** Events of interest occurring in this class are logged to this logger. */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(NewAccountPanel.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(NewAccountPanel.class.getName());
 
     /** Events of interest occurring in this class are logged to this logger. */
 

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -25,7 +25,7 @@ public class ProblemInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(ProblemInputView.class);
 
     /** The logger for the class */
-    private static final Logger LOGGER = Logger.getLogger(ProblemInputView.class.getName());
+    private static final Logger julLogger = Logger.getLogger(ProblemInputView.class.getName());
 
     private ProblemListener submitListener;
 
@@ -34,7 +34,7 @@ public class ProblemInputView extends JPanel {
     public ProblemInputView(ProblemListener listener) {
         super(new BorderLayout());
         submitListener = listener;
-        ProblemInputView.LOGGER.log(Level.INFO, "Initializing ProblemInputView");
+        ProblemInputView.julLogger.log(Level.INFO, "Initializing ProblemInputView");
     }
 
     public void setModel(Problem problem) {
@@ -47,22 +47,22 @@ public class ProblemInputView extends JPanel {
 
         switch (kind) {
             case LCS_PROBLEM:
-                ProblemInputView.LOGGER.log(Level.INFO, "Setting currentPanel to LCSInputView");
+                ProblemInputView.julLogger.log(Level.INFO, "Setting currentPanel to LCSInputView");
                 currentPanel = new LCSInputView(submitListener);
                 break;
             case MATRIX_CHAIN:
-                ProblemInputView.LOGGER.log(Level.INFO, "Setting currentPanel to MatrixInputView");
+                ProblemInputView.julLogger.log(Level.INFO, "Setting currentPanel to MatrixInputView");
                 currentPanel = new MatrixInputView();
                 break;
             case KNAPSACK_0_1:
-                ProblemInputView.LOGGER.log(
+                ProblemInputView.julLogger.log(
                         Level.INFO, "Setting currentPanel to KnapsackInputView");
                 currentPanel = new KnapsackInputView();
                 // TODO: Uncomment and load KnapsackInputView once KnapsackProblem and its view are
                 // implemented:
                 // KnapsackInputView knapsackInputView = new KnapsackInputView();
                 // add(knapsackInputView, BorderLayout.CENTER);
-                ProblemInputView.LOGGER.log(
+                ProblemInputView.julLogger.log(
                         Level.SEVERE, "Knapsack input view not yet implemented.");
                 break;
             default:

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -3,7 +3,6 @@ package edu.regis.dptu.view;
 import java.awt.BorderLayout;
 import java.util.logging.Level;
 
-
 import javax.swing.JPanel;
 
 import org.slf4j.Logger;

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -1,6 +1,8 @@
 package edu.regis.dptu.view;
 
-import java.awt.BorderLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,6 +22,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author EverettCV
  */
 public class ProblemInputView extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(ProblemInputView.class);
+
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(ProblemInputView.class.getName());
 

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -1,12 +1,13 @@
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
+import java.awt.BorderLayout;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JPanel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -1,7 +1,7 @@
 package edu.regis.dptu.view;
 
 import java.awt.BorderLayout;
-import java.util.logging.Level;
+
 
 import javax.swing.JPanel;
 
@@ -35,7 +35,7 @@ public class ProblemInputView extends JPanel {
     public ProblemInputView(ProblemListener listener) {
         super(new BorderLayout());
         submitListener = listener;
-        ProblemInputView.julLogger.log(Level.INFO, "Initializing ProblemInputView");
+        ProblemInputView.julLogger.log(java.util.logging.Level.INFO, "Initializing ProblemInputView");
     }
 
     public void setModel(Problem problem) {
@@ -48,24 +48,24 @@ public class ProblemInputView extends JPanel {
 
         switch (kind) {
             case LCS_PROBLEM:
-                ProblemInputView.julLogger.log(Level.INFO, "Setting currentPanel to LCSInputView");
+                ProblemInputView.julLogger.log(java.util.logging.Level.INFO, "Setting currentPanel to LCSInputView");
                 currentPanel = new LCSInputView(submitListener);
                 break;
             case MATRIX_CHAIN:
                 ProblemInputView.julLogger.log(
-                        Level.INFO, "Setting currentPanel to MatrixInputView");
+                        java.util.logging.Level.INFO, "Setting currentPanel to MatrixInputView");
                 currentPanel = new MatrixInputView();
                 break;
             case KNAPSACK_0_1:
                 ProblemInputView.julLogger.log(
-                        Level.INFO, "Setting currentPanel to KnapsackInputView");
+                        java.util.logging.Level.INFO, "Setting currentPanel to KnapsackInputView");
                 currentPanel = new KnapsackInputView();
                 // TODO: Uncomment and load KnapsackInputView once KnapsackProblem and its view are
                 // implemented:
                 // KnapsackInputView knapsackInputView = new KnapsackInputView();
                 // add(knapsackInputView, BorderLayout.CENTER);
                 ProblemInputView.julLogger.log(
-                        Level.SEVERE, "Knapsack input view not yet implemented.");
+                        java.util.logging.Level.SEVERE, "Knapsack input view not yet implemented.");
                 break;
             default:
                 throw new IllegalArgumentException(

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -2,7 +2,7 @@ package edu.regis.dptu.view;
 
 import java.awt.BorderLayout;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import javax.swing.JPanel;
 

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -25,7 +25,7 @@ public class ProblemInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(ProblemInputView.class);
 
     /** The logger for the class */
-    private static final Logger julLogger = Logger.getLogger(ProblemInputView.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(ProblemInputView.class.getName());
 
     private ProblemListener submitListener;
 

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -51,7 +51,8 @@ public class ProblemInputView extends JPanel {
                 currentPanel = new LCSInputView(submitListener);
                 break;
             case MATRIX_CHAIN:
-                ProblemInputView.julLogger.log(Level.INFO, "Setting currentPanel to MatrixInputView");
+                ProblemInputView.julLogger.log(
+                        Level.INFO, "Setting currentPanel to MatrixInputView");
                 currentPanel = new MatrixInputView();
                 break;
             case KNAPSACK_0_1:

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -25,7 +25,8 @@ public class ProblemInputView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(ProblemInputView.class);
 
     /** The logger for the class */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(ProblemInputView.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(ProblemInputView.class.getName());
 
     private ProblemListener submitListener;
 

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -2,7 +2,6 @@ package edu.regis.dptu.view;
 
 import java.awt.BorderLayout;
 
-
 import javax.swing.JPanel;
 
 import org.slf4j.Logger;
@@ -35,7 +34,8 @@ public class ProblemInputView extends JPanel {
     public ProblemInputView(ProblemListener listener) {
         super(new BorderLayout());
         submitListener = listener;
-        ProblemInputView.julLogger.log(java.util.logging.Level.INFO, "Initializing ProblemInputView");
+        ProblemInputView.julLogger.log(
+                java.util.logging.Level.INFO, "Initializing ProblemInputView");
     }
 
     public void setModel(Problem problem) {
@@ -48,7 +48,8 @@ public class ProblemInputView extends JPanel {
 
         switch (kind) {
             case LCS_PROBLEM:
-                ProblemInputView.julLogger.log(java.util.logging.Level.INFO, "Setting currentPanel to LCSInputView");
+                ProblemInputView.julLogger.log(
+                        java.util.logging.Level.INFO, "Setting currentPanel to LCSInputView");
                 currentPanel = new LCSInputView(submitListener);
                 break;
             case MATRIX_CHAIN:

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.CardLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.CardLayout;
 import java.awt.Dimension;
 
 import javax.swing.JButton;
@@ -33,6 +35,8 @@ import edu.regis.dptu.model.User;
  * @author rickb (modified)
  */
 public class SplashFrame extends JFrame {
+    private static final Logger log = LoggerFactory.getLogger(SplashFrame.class);
+
     /** Name of the splash panel in this frame's primary card layout panel. */
     public static final String SPLASH = "SplashPanel";
 

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.CardLayout;
+import java.awt.CardLayout;
 import java.awt.Dimension;
 
 import javax.swing.JButton;
@@ -22,6 +20,9 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Problem;

--- a/src/main/java/edu/regis/dptu/view/SplashPanel.java
+++ b/src/main/java/edu/regis/dptu/view/SplashPanel.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -27,6 +25,9 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.User;
 import edu.regis.dptu.util.SHA_256;

--- a/src/main/java/edu/regis/dptu/view/SplashPanel.java
+++ b/src/main/java/edu/regis/dptu/view/SplashPanel.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -40,6 +42,8 @@ import edu.regis.dptu.view.act.SignInAction;
  * @author rickb
  */
 public class SplashPanel extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(SplashPanel.class);
+
     /** Events of interest occurring in this class are logged to this logger. */
 
     /** The user model displayed in this view. */

--- a/src/main/java/edu/regis/dptu/view/StepCompletionReplyView.java
+++ b/src/main/java/edu/regis/dptu/view/StepCompletionReplyView.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.CardLayout;
+import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -22,6 +20,9 @@ import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Displays the result of a student completing a step, which gives the student a suggestion as to

--- a/src/main/java/edu/regis/dptu/view/StepCompletionReplyView.java
+++ b/src/main/java/edu/regis/dptu/view/StepCompletionReplyView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.CardLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -28,6 +30,8 @@ import javax.swing.JTextArea;
  * @author rickb
  */
 public class StepCompletionReplyView extends GPanel implements ActionListener {
+    private static final Logger log = LoggerFactory.getLogger(StepCompletionReplyView.class);
+
     /** Message displayed to the student. */
     private JTextArea msg;
 

--- a/src/main/java/edu/regis/dptu/view/StepCompletionView.java
+++ b/src/main/java/edu/regis/dptu/view/StepCompletionView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.BorderLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Font;
 
@@ -34,6 +36,8 @@ import edu.regis.dptu.view.act.RequestHintAction;
  * types (cell completion, row initialization, etc.).
  */
 public class StepCompletionView extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(StepCompletionView.class);
+
 
     // The current step being worked on
     protected Step currentStep;

--- a/src/main/java/edu/regis/dptu/view/StepCompletionView.java
+++ b/src/main/java/edu/regis/dptu/view/StepCompletionView.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
+import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Font;
 
@@ -23,6 +21,9 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Step;
 import edu.regis.dptu.model.StepCompletion;
@@ -37,7 +38,6 @@ import edu.regis.dptu.view.act.RequestHintAction;
  */
 public class StepCompletionView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(StepCompletionView.class);
-
 
     // The current step being worked on
     protected Step currentStep;

--- a/src/main/java/edu/regis/dptu/view/StepSelectorView.java
+++ b/src/main/java/edu/regis/dptu/view/StepSelectorView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.BorderLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -40,6 +42,8 @@ import edu.regis.dptu.model.aol.AssessmentLevel;
  * with different status indicators (not started, in progress, completed).
  */
 public class StepSelectorView extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(StepSelectorView.class);
+
 
     /** Enum representing the different step selections available. */
     public enum StepSelection {

--- a/src/main/java/edu/regis/dptu/view/StepSelectorView.java
+++ b/src/main/java/edu/regis/dptu/view/StepSelectorView.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -32,6 +30,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.Step;
 import edu.regis.dptu.model.StepSubType;
 import edu.regis.dptu.model.Task;
@@ -43,7 +44,6 @@ import edu.regis.dptu.model.aol.AssessmentLevel;
  */
 public class StepSelectorView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(StepSelectorView.class);
-
 
     /** Enum representing the different step selections available. */
     public enum StepSelection {

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -29,6 +27,9 @@ import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -40,7 +41,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 public class StepViewPanel extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(StepViewPanel.class);
-
 
     /** The problem model that this view controls. */
     private Problem model; // Initialize as null

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -37,6 +39,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author Shamar Henry
  */
 public class StepViewPanel extends GPanel implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(StepViewPanel.class);
+
 
     /** The problem model that this view controls. */
     private Problem model; // Initialize as null

--- a/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.Color;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
@@ -26,6 +28,8 @@ import javax.swing.JPanel;
  * @author Sofia Reyes
  */
 public class SubSequenceCanvasView extends JPanel {
+    private static final Logger log = LoggerFactory.getLogger(SubSequenceCanvasView.class);
+
 
     private String word1;
     private String word2;

--- a/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
@@ -12,14 +12,15 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Color;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 
 import javax.swing.JPanel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the Subsequence Canvas view. Two words are displayed aside each other, and shows a
@@ -29,7 +30,6 @@ import javax.swing.JPanel;
  */
 public class SubSequenceCanvasView extends JPanel {
     private static final Logger log = LoggerFactory.getLogger(SubSequenceCanvasView.class);
-
 
     private String word1;
     private String word2;

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -17,7 +17,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
-import java.util.logging.Level;
+
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -187,7 +187,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
             this.model.addProblemListener(this);
 
             julLogger.log(
-                    Level.INFO,
+                    java.util.logging.Level.INFO,
                     "SubSequenceView: model set ({0}), updating view",
                     this.model.getClass().getSimpleName());
 
@@ -206,7 +206,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
     @Override
     public void problemUpdated(Problem problem) {
 
-        julLogger.log(Level.FINE, "SubSequenceView: problemUpdated called");
+        julLogger.log(java.util.logging.Level.FINE, "SubSequenceView: problemUpdated called");
 
         // Update the UI on the Swing thread to avoid race conditions.
         SwingUtilities.invokeLater(this::updateView);
@@ -229,7 +229,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
             updateWords(x, y);
         } else if (model != null) {
             julLogger.log(
-                    Level.FINE,
+                    java.util.logging.Level.FINE,
                     "SubSequenceView: model is not LCSProblem; " + "no word update performed");
         }
 

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -43,7 +43,7 @@ import edu.regis.dptu.model.ProblemListener;
 class SubSequenceView extends JPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(SubSequenceView.class);
 
-    private static final java.util.logging.Logger LOGGER =
+    private static final java.util.logging.Logger julLogger =
             java.util.logging.Logger.getLogger(SubSequenceView.class.getName());
 
     private JLabel titleLabel, lengthLabel1, lengthLabel2, wordLabel1, wordLabel2;
@@ -186,14 +186,14 @@ class SubSequenceView extends JPanel implements ProblemListener {
 
             this.model.addProblemListener(this);
 
-            LOGGER.log(
+            julLogger.log(
                     Level.INFO,
                     "SubSequenceView: model set ({0}), updating view",
                     this.model.getClass().getSimpleName());
 
             updateView();
         } else {
-            LOGGER.warning("SubSequenceView: setModel called with a null model");
+            julLogger.warning("SubSequenceView: setModel called with a null model");
         }
     }
 
@@ -206,7 +206,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
     @Override
     public void problemUpdated(Problem problem) {
 
-        LOGGER.log(Level.FINE, "SubSequenceView: problemUpdated called");
+        julLogger.log(Level.FINE, "SubSequenceView: problemUpdated called");
 
         // Update the UI on the Swing thread to avoid race conditions.
         SwingUtilities.invokeLater(this::updateView);
@@ -228,7 +228,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
             // Update the view with the current words.
             updateWords(x, y);
         } else if (model != null) {
-            LOGGER.log(
+            julLogger.log(
                     Level.FINE,
                     "SubSequenceView: model is not LCSProblem; " + "no word update performed");
         }

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -12,9 +12,7 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -26,6 +24,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
@@ -41,7 +42,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 class SubSequenceView extends JPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(SubSequenceView.class);
-
 
     private static final java.util.logging.Logger LOGGER =
             java.util.logging.Logger.getLogger(SubSequenceView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -18,7 +18,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 
-
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.BorderLayout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -38,6 +40,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author Sofia Reyes
  */
 class SubSequenceView extends JPanel implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(SubSequenceView.class);
+
 
     private static final java.util.logging.Logger LOGGER =
             java.util.logging.Logger.getLogger(SubSequenceView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-// Keep ALL original imports
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;// Keep ALL original imports
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -48,6 +50,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author Corey Brantley (Modified by Assistant for Update Logic)
  */
 public class SubproblemTableView extends GPanel implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(SubproblemTableView.class);
+
 
     // Model representing the dynamic programming problem
     private Problem model;

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -12,9 +12,6 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;// Keep ALL original imports
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -37,6 +34,9 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
@@ -51,7 +51,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 public class SubproblemTableView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(SubproblemTableView.class);
-
 
     // Model representing the dynamic programming problem
     private Problem model;

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.GridBagConstraints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,6 +30,8 @@ import edu.regis.dptu.model.TutoringSession;
  * @author rickb (Modified by Assistant for Functional Integration & Debug)
  */
 public class TutoringSessionView extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(TutoringSessionView.class);
+
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(TutoringSessionView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -142,7 +142,8 @@ public class TutoringSessionView extends GPanel {
      * relevant views get the *same* Problem model instance.
      */
     private void initializeComponents() {
-        TutoringSessionView.julLogger.log(Level.INFO, "TutoringSessionView initializing components");
+        TutoringSessionView.julLogger.log(
+                Level.INFO, "TutoringSessionView initializing components");
         variablesView = new VariablesView();
         subproblemView = new JLabel("Subproblem View");
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -14,7 +14,7 @@ package edu.regis.dptu.view;
 
 import java.awt.GridBagConstraints;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 import javax.swing.JLabel;
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -33,7 +33,7 @@ public class TutoringSessionView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(TutoringSessionView.class);
 
     /** The logger for the class */
-    private static final Logger julLogger = Logger.getLogger(TutoringSessionView.class.getName());
+    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(TutoringSessionView.class.getName());
 
     private TutoringSession model;
     private VariablesView variablesView;

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -13,7 +13,7 @@
 package edu.regis.dptu.view;
 
 import java.awt.GridBagConstraints;
-import java.util.logging.Level;
+
 
 import javax.swing.JLabel;
 
@@ -55,7 +55,7 @@ public class TutoringSessionView extends GPanel {
      * layout.
      */
     public TutoringSessionView() {
-        TutoringSessionView.julLogger.log(Level.INFO, "Initiating TutoringSessionView");
+        TutoringSessionView.julLogger.log(java.util.logging.Level.INFO, "Initiating TutoringSessionView");
         initializeComponents(); // Creates components and sets up model sharing
         layoutComponents(); // Uses original layout constraints
     }
@@ -144,7 +144,7 @@ public class TutoringSessionView extends GPanel {
      */
     private void initializeComponents() {
         TutoringSessionView.julLogger.log(
-                Level.INFO, "TutoringSessionView initializing components");
+                java.util.logging.Level.INFO, "TutoringSessionView initializing components");
         variablesView = new VariablesView();
         subproblemView = new JLabel("Subproblem View");
 
@@ -304,7 +304,7 @@ public class TutoringSessionView extends GPanel {
     }
 
     private void updateView(Problem currentProblem) {
-        TutoringSessionView.julLogger.log(Level.INFO, "TutoringSessionView updating view");
+        TutoringSessionView.julLogger.log(java.util.logging.Level.INFO, "TutoringSessionView updating view");
 
         problemInputView.setModel(currentProblem);
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -14,7 +14,6 @@ package edu.regis.dptu.view;
 
 import java.awt.GridBagConstraints;
 
-
 import javax.swing.JLabel;
 
 import org.slf4j.Logger;
@@ -55,7 +54,8 @@ public class TutoringSessionView extends GPanel {
      * layout.
      */
     public TutoringSessionView() {
-        TutoringSessionView.julLogger.log(java.util.logging.Level.INFO, "Initiating TutoringSessionView");
+        TutoringSessionView.julLogger.log(
+                java.util.logging.Level.INFO, "Initiating TutoringSessionView");
         initializeComponents(); // Creates components and sets up model sharing
         layoutComponents(); // Uses original layout constraints
     }
@@ -304,7 +304,8 @@ public class TutoringSessionView extends GPanel {
     }
 
     private void updateView(Problem currentProblem) {
-        TutoringSessionView.julLogger.log(java.util.logging.Level.INFO, "TutoringSessionView updating view");
+        TutoringSessionView.julLogger.log(
+                java.util.logging.Level.INFO, "TutoringSessionView updating view");
 
         problemInputView.setModel(currentProblem);
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -12,13 +12,14 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
+import java.awt.GridBagConstraints;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.JLabel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.TutoringSession;
@@ -31,7 +32,6 @@ import edu.regis.dptu.model.TutoringSession;
  */
 public class TutoringSessionView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(TutoringSessionView.class);
-
 
     /** The logger for the class */
     private static final Logger LOGGER = Logger.getLogger(TutoringSessionView.class.getName());

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -33,7 +33,8 @@ public class TutoringSessionView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(TutoringSessionView.class);
 
     /** The logger for the class */
-    private static final java.util.logging.Logger julLogger =  java.util.logging.Logger.getLogger(TutoringSessionView.class.getName());
+    private static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(TutoringSessionView.class.getName());
 
     private TutoringSession model;
     private VariablesView variablesView;

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -33,7 +33,7 @@ public class TutoringSessionView extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(TutoringSessionView.class);
 
     /** The logger for the class */
-    private static final Logger LOGGER = Logger.getLogger(TutoringSessionView.class.getName());
+    private static final Logger julLogger = Logger.getLogger(TutoringSessionView.class.getName());
 
     private TutoringSession model;
     private VariablesView variablesView;
@@ -54,7 +54,7 @@ public class TutoringSessionView extends GPanel {
      * layout.
      */
     public TutoringSessionView() {
-        TutoringSessionView.LOGGER.log(Level.INFO, "Initiating TutoringSessionView");
+        TutoringSessionView.julLogger.log(Level.INFO, "Initiating TutoringSessionView");
         initializeComponents(); // Creates components and sets up model sharing
         layoutComponents(); // Uses original layout constraints
     }
@@ -142,7 +142,7 @@ public class TutoringSessionView extends GPanel {
      * relevant views get the *same* Problem model instance.
      */
     private void initializeComponents() {
-        TutoringSessionView.LOGGER.log(Level.INFO, "TutoringSessionView initializing components");
+        TutoringSessionView.julLogger.log(Level.INFO, "TutoringSessionView initializing components");
         variablesView = new VariablesView();
         subproblemView = new JLabel("Subproblem View");
 
@@ -302,7 +302,7 @@ public class TutoringSessionView extends GPanel {
     }
 
     private void updateView(Problem currentProblem) {
-        TutoringSessionView.LOGGER.log(Level.INFO, "TutoringSessionView updating view");
+        TutoringSessionView.julLogger.log(Level.INFO, "TutoringSessionView updating view");
 
         problemInputView.setModel(currentProblem);
 

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -15,7 +15,6 @@ package edu.regis.dptu.view;
 import java.awt.GridBagConstraints;
 import java.util.logging.Level;
 
-
 import javax.swing.JLabel;
 
 import org.slf4j.Logger;

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view;
 
-import java.awt.GridBagConstraints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
 
@@ -22,6 +24,8 @@ import edu.regis.dptu.model.Problem;
  * @author danielaflores
  */
 public class VariablesView extends GPanel {
+    private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
+
     private Problem model;
     private JLabel rName, rValue, cName, cValue, iName, iValue, jName, jValue, lName, lValue;
 

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,11 +12,12 @@
  */
 package edu.regis.dptu.view;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.GridBagConstraints;
+import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
 

--- a/src/main/java/edu/regis/dptu/view/act/BackAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/BackAction.java
@@ -12,10 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.SplashFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/BackAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/BackAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import edu.regis.dptu.view.SplashFrame;
@@ -24,6 +26,8 @@ import edu.regis.dptu.view.SplashFrame;
  * @author rickb
  */
 public class BackAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(BackAction.class);
+
     /** The single instance of this new user action. */
     private static final BackAction SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/act/CheckAnswerAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/CheckAnswerAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
@@ -26,6 +28,8 @@ import edu.regis.dptu.view.MainFrame;
  * integrated.
  */
 public class CheckAnswerAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(CheckAnswerAction.class);
+
     /** The singleton instance of this action. */
     private static final CheckAnswerAction SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/act/CheckAnswerAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/CheckAnswerAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.MainFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/CreateAcctAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/CreateAcctAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
@@ -33,6 +35,8 @@ import edu.regis.dptu.view.SplashFrame;
  * @author rickb
  */
 public class CreateAcctAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(CreateAcctAction.class);
+
 
     /** The single instance of this create account action. */
     private static final CreateAcctAction SINGLETON;

--- a/src/main/java/edu/regis/dptu/view/act/CreateAcctAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/CreateAcctAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
@@ -36,7 +37,6 @@ import edu.regis.dptu.view.SplashFrame;
  */
 public class CreateAcctAction extends DpTuGuiAction {
     private static final Logger log = LoggerFactory.getLogger(CreateAcctAction.class);
-
 
     /** The single instance of this create account action. */
     private static final CreateAcctAction SINGLETON;

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -12,10 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.MainFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -12,12 +12,16 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import edu.regis.dptu.view.MainFrame;
 
 public class DoOneAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(DoOneAction.class);
+
     private static final DoOneAction SINGLETON;
 
     static {

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -13,7 +13,7 @@
 package edu.regis.dptu.view.act;
 
 import java.awt.Image;
-import java.util.logging.Logger;
+
 
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -12,13 +12,14 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.Image;
+import java.awt.Image;
 import java.util.logging.Logger;
 
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.util.ImgFactory;
 

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -14,7 +14,6 @@ package edu.regis.dptu.view.act;
 
 import java.awt.Image;
 
-
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
 

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.Image;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.Image;
 import java.util.logging.Logger;
 
 import javax.swing.AbstractAction;
@@ -28,6 +30,8 @@ import edu.regis.dptu.util.ImgFactory;
  * @author rickb
  */
 public abstract class DpTuGuiAction extends AbstractAction {
+    private static final Logger log = LoggerFactory.getLogger(DpTuGuiAction.class);
+
     protected static final Logger LOGGER = Logger.getLogger(DpTuGuiAction.class.getName());
 
     public DpTuGuiAction(String name) {

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -12,27 +12,25 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.Image;
-
-import javax.swing.AbstractAction;
-import javax.swing.ImageIcon;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.Image;
+import javax.swing.AbstractAction;
+import javax.swing.ImageIcon;
 
 import edu.regis.dptu.util.ImgFactory;
 
 /**
- * Abstract root for all GUI actions in the SpTu application.
+ * Abstract root for all GUI actions in the DpTu application.
  *
  * <p>Provides support for loading image icons and assigning the GUI controller.
- *
- * @author rickb
  */
 public abstract class DpTuGuiAction extends AbstractAction {
     private static final Logger log = LoggerFactory.getLogger(DpTuGuiAction.class);
 
-    protected static final Logger julLogger = Logger.getLogger(DpTuGuiAction.class.getName());
+    protected static final java.util.logging.Logger julLogger =
+            java.util.logging.Logger.getLogger(DpTuGuiAction.class.getName());
 
     public DpTuGuiAction(String name) {
         super(name);

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.Image;
+
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.util.ImgFactory;
 

--- a/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DpTuGuiAction.java
@@ -32,7 +32,7 @@ import edu.regis.dptu.util.ImgFactory;
 public abstract class DpTuGuiAction extends AbstractAction {
     private static final Logger log = LoggerFactory.getLogger(DpTuGuiAction.class);
 
-    protected static final Logger LOGGER = Logger.getLogger(DpTuGuiAction.class.getName());
+    protected static final Logger julLogger = Logger.getLogger(DpTuGuiAction.class.getName());
 
     public DpTuGuiAction(String name) {
         super(name);

--- a/src/main/java/edu/regis/dptu/view/act/NewExampleAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/NewExampleAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.MainFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/NewExampleAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/NewExampleAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
@@ -26,6 +28,8 @@ import edu.regis.dptu.view.MainFrame;
  * integrated.
  */
 public class NewExampleAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(NewExampleAction.class);
+
     /** The singleton instance of this action. */
     private static final NewExampleAction SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/act/NewUserAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/NewUserAction.java
@@ -12,10 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.SplashFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/NewUserAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/NewUserAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import edu.regis.dptu.view.SplashFrame;
@@ -24,6 +26,8 @@ import edu.regis.dptu.view.SplashFrame;
  * @author rickb
  */
 public class NewUserAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(NewUserAction.class);
+
     /** The single instance of this new user action. */
     private static final NewUserAction SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/act/RequestHintAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/RequestHintAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.MainFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/RequestHintAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/RequestHintAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JOptionPane;
@@ -26,6 +28,8 @@ import edu.regis.dptu.view.MainFrame;
  * integrated.
  */
 public class RequestHintAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(RequestHintAction.class);
+
     /** The singleton instance of this action. */
     private static final RequestHintAction SINGLETON;
 

--- a/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.KeyStroke;
@@ -25,6 +27,8 @@ import edu.regis.dptu.util.ImgFactory;
  * @author rickb
  */
 public class SaveSessionAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(SaveSessionAction.class);
+
 
     /**
      * Create the singleton for this action, which occurs when this class is loaded by the Java

--- a/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
@@ -12,12 +12,13 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.KeyStroke;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.util.ImgFactory;
 
@@ -28,7 +29,6 @@ import edu.regis.dptu.util.ImgFactory;
  */
 public class SaveSessionAction extends DpTuGuiAction {
     private static final Logger log = LoggerFactory.getLogger(SaveSessionAction.class);
-
 
     /**
      * Create the singleton for this action, which occurs when this class is loaded by the Java

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -14,7 +14,7 @@ package edu.regis.dptu.view.act;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
-import java.util.logging.Level;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ public class SeeOneAction extends DpTuGuiAction {
             SplashFrame.instance().selectLessonScreen(problem);
 
         } catch (ObjNotFoundException | NonRecoverableException e) {
-            SeeOneAction.julLogger.log(Level.SEVERE, e.getMessage());
+            SeeOneAction.julLogger.log(java.util.logging.Level.SEVERE, e.getMessage());
             SplashFrame.instance().showError("Error", "Failed to load problem");
         }
     }

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -12,11 +12,12 @@
  */
 package edu.regis.dptu.view.act;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.dao.ProblemDAO;
 import edu.regis.dptu.err.NonRecoverableException;

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.logging.Level;
 
@@ -25,6 +27,8 @@ import edu.regis.dptu.view.DashboardPanel;
 import edu.regis.dptu.view.SplashFrame;
 
 public class SeeOneAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(SeeOneAction.class);
+
     private static final SeeOneAction SINGLETON;
 
     private final ProblemDAO problemDAO;

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -64,7 +64,7 @@ public class SeeOneAction extends DpTuGuiAction {
             SplashFrame.instance().selectLessonScreen(problem);
 
         } catch (ObjNotFoundException | NonRecoverableException e) {
-            SeeOneAction.LOGGER.log(Level.SEVERE, e.getMessage());
+            SeeOneAction.julLogger.log(Level.SEVERE, e.getMessage());
             SplashFrame.instance().showError("Error", "Failed to load problem");
         }
     }

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -15,7 +15,6 @@ package edu.regis.dptu.view.act;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import edu.regis.dptu.model.Account;
@@ -29,6 +31,8 @@ import edu.regis.dptu.view.SplashFrame;
  * @author rickb
  */
 public class SignInAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(SignInAction.class);
+
     private static final SignInAction SINGLETON;
 
     static {

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -12,10 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Student;

--- a/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
@@ -12,10 +12,11 @@
  */
 package edu.regis.dptu.view.act;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
+import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.view.MainFrame;
 

--- a/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
@@ -12,12 +12,16 @@
  */
 package edu.regis.dptu.view.act;
 
-import java.awt.event.ActionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 import edu.regis.dptu.view.MainFrame;
 
 public class TeachOneAction extends DpTuGuiAction {
+    private static final Logger log = LoggerFactory.getLogger(TeachOneAction.class);
+
     private static final TeachOneAction SINGLETON;
 
     static {

--- a/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
@@ -12,13 +12,13 @@
  */
 package edu.regis.dptu.test;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,7 +29,6 @@ import edu.regis.dptu.model.LCSProblem;
  */
 public class LCSProblemTest {
     private static final Logger log = LoggerFactory.getLogger(LCSProblemTest.class);
-
 
     public LCSProblemTest() {}
 

--- a/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.test;
 
-import org.junit.jupiter.api.AfterAll;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +28,8 @@ import edu.regis.dptu.model.LCSProblem;
  * @author rickb
  */
 public class LCSProblemTest {
+    private static final Logger log = LoggerFactory.getLogger(LCSProblemTest.class);
+
 
     public LCSProblemTest() {}
 

--- a/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.test;
 
-import org.junit.jupiter.api.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,6 +24,8 @@ import edu.regis.dptu.model.MatrixChainProblem;
  * @author corey
  */
 public class MatrixChainProblemTest {
+    private static final Logger log = LoggerFactory.getLogger(MatrixChainProblemTest.class);
+
 
     @Test
     public void testMatrixChainExecution() {

--- a/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
@@ -12,9 +12,9 @@
  */
 package edu.regis.dptu.test;
 
-
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,7 +25,6 @@ import edu.regis.dptu.model.MatrixChainProblem;
  */
 public class MatrixChainProblemTest {
     private static final Logger log = LoggerFactory.getLogger(MatrixChainProblemTest.class);
-
 
     @Test
     public void testMatrixChainExecution() {

--- a/src/test/java/edu/regis/dptu/test/TestStepExecution.java
+++ b/src/test/java/edu/regis/dptu/test/TestStepExecution.java
@@ -12,7 +12,9 @@
  */
 package edu.regis.dptu.test;
 
-import edu.regis.dptu.model.LCSProblem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -23,6 +25,8 @@ import edu.regis.dptu.model.ProblemListener;
  * @author [your name]
  */
 public class TestStepExecution implements ProblemListener {
+    private static final Logger log = LoggerFactory.getLogger(TestStepExecution.class);
+
 
     /** Main entry point for the test */
     public static void main(String[] args) {

--- a/src/test/java/edu/regis/dptu/test/TestStepExecution.java
+++ b/src/test/java/edu/regis/dptu/test/TestStepExecution.java
@@ -12,9 +12,10 @@
  */
 package edu.regis.dptu.test;
 
-
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;import edu.regis.dptu.model.LCSProblem;
+import org.slf4j.LoggerFactory;
+
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -26,7 +27,6 @@ import edu.regis.dptu.model.ProblemListener;
  */
 public class TestStepExecution implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(TestStepExecution.class);
-
 
     /** Main entry point for the test */
     public static void main(String[] args) {


### PR DESCRIPTION
Full PR Notes:

Adding SLF4J imports to all classes and a logger object.
All conflicting legacy loggers are being renamed julLogger until I get to them later.
I'm removing all JUL imports and instead using explicit declarations. This provides a cleaner path forward.

Not In Scope (yet):
Actually, replacing JUL logging.