### PR TITLE
DPTU-93 VariablesView now displays variable values

### DIFF
--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -67,10 +67,8 @@ public class LCSProblem extends Problem {
 
     /** Input sequence 2. (Stored in variables map) */
     private final String y; // Keep original field if needed
-    
-    /**
-     * This keeps track of the lcs as determined by the backtracking algorithm
-     */
+
+    /** This keeps track of the lcs as determined by the backtracking algorithm */
     private String currentLcs = "";
 
     /**
@@ -142,7 +140,7 @@ public class LCSProblem extends Problem {
     public String getY() {
         return y;
     }
-    
+
     public String getCurrentLcs() {
         return currentLcs;
     }

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -67,6 +67,11 @@ public class LCSProblem extends Problem {
 
     /** Input sequence 2. (Stored in variables map) */
     private final String y; // Keep original field if needed
+    
+    /**
+     * This keeps track of the lcs as determined by the backtracking algorithm
+     */
+    private String currentLcs = "";
 
     /**
      * The current state of the algorithm, before the loops, in a loop, and after all of the loops
@@ -137,6 +142,10 @@ public class LCSProblem extends Problem {
     public String getY() {
         return y;
     }
+    
+    public String getCurrentLcs() {
+        return currentLcs;
+    }
 
     /**
      * {@inheritDoc}
@@ -173,6 +182,8 @@ public class LCSProblem extends Problem {
                 bTable[row][col] = -1;
             }
         }
+        // Since we're resetting the backtracking table, we also reset the lcs
+        currentLcs = "";
     }
 
     /**
@@ -312,7 +323,7 @@ public class LCSProblem extends Problem {
         backtrackingCodeStatements.add(
                 "<html><pre><b>BACKTRACK(table L)</b></pre></html>"); // line 0
         backtrackingCodeStatements.add(
-                "<html><pre>row = x.length - 1, col = y.length - 1</pre></html>"); // line 1
+                "<html><pre>row = n - 1, col = m - 1</pre></html>"); // line 1
         backtrackingCodeStatements.add(
                 "<html><pre>while(row >= 0 && col >= 0)</pre></html>"); // line 2
         backtrackingCodeStatements.add("<html><pre>  if (x[row] == y[col])</pre></html>"); // line 3
@@ -669,6 +680,7 @@ public class LCSProblem extends Problem {
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
         bTable[row][col] = ADD_TO_SOLUTION; // highlight in green
+        currentLcs = y.charAt(col - 1) + currentLcs;
         nextLineNumber = 105;
     }
 
@@ -899,6 +911,7 @@ public class LCSProblem extends Problem {
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
         bTable[row][col] = HIT; // highlight in yellow
+        currentLcs = currentLcs.substring(1);
     }
 
     /** Undoes executeLine105: row-- */

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -44,8 +44,8 @@ public class GPanel extends JPanel {
      * &nbsp;&nbsp; GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH, &nbsp;&nbsp; 5,5,5,5);
      *
      * @param c the child component
-     * @param gridX the row in which the child component is anchored
-     * @param gridY the column in which the child component is anchored
+     * @param gridX the column in which the child component is anchored
+     * @param gridY the row in which the child component is anchored
      * @param gridWidth the rows spanned by the child component in the bag
      * @param gridHeight the cols spanned by the child component in the bag
      * @param weightx the amount of width scaling during panel expansion
@@ -59,8 +59,8 @@ public class GPanel extends JPanel {
      */
     public void addc(
             Component c,
-            int gridX,
-            int gridY,
+            int gridX, // column
+            int gridY, // row
             int gridWidth,
             int gridHeight,
             double weightx,

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -69,10 +69,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
         titleLabel.setFont(new Font("Segoe UI", Font.BOLD, 18));
         titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
-        lengthLabel1 = new JLabel("x=");
+        lengthLabel1 = new JLabel();
         lengthLabel1.setFont(new Font("Arial", Font.PLAIN, 16));
 
-        lengthLabel2 = new JLabel("y=");
+        lengthLabel2 = new JLabel();
         lengthLabel2.setFont(new Font("Arial", Font.PLAIN, 16));
 
         stepButton = new JButton("Step LCS");
@@ -154,8 +154,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
      */
     public void updateWords(String word1, String word2) {
         // Update lengths
-        lengthLabel1.setText("x=" + word1.length());
-        lengthLabel2.setText("y=" + word2.length());
+        lengthLabel1.setText("n=" + word1.length());
+        lengthLabel2.setText("m=" + word2.length());
 
         wordLabel1.setText(word1);
         wordLabel2.setText(word2);

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -70,10 +70,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
         titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         lengthLabel1 = new JLabel();
-        lengthLabel1.setFont(new Font("Arial", Font.PLAIN, 16));
+        lengthLabel1.setFont(new Font("Dialog", Font.PLAIN, 16));
 
         lengthLabel2 = new JLabel();
-        lengthLabel2.setFont(new Font("Arial", Font.PLAIN, 16));
+        lengthLabel2.setFont(new Font("Dialog", Font.PLAIN, 16));
 
         stepButton = new JButton("Step LCS");
         stepButton.addActionListener(e -> stepThroughLCS());
@@ -97,6 +97,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
         JPanel line1 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line1.add(lengthLabel1);
         wordLabel1 = new JLabel();
+        wordLabel1.setFont(new Font("Dialog", Font.PLAIN, 16));
         line1.add(wordLabel1);
 
         // Changed (April 17, 2025 - EverettCV): Now loads default value of the second variable
@@ -104,6 +105,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
         JPanel line2 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line2.add(lengthLabel2);
         wordLabel2 = new JLabel();
+        wordLabel2.setFont(new Font("Dialog", Font.PLAIN, 16));
         line2.add(wordLabel2);
 
         wordPanel.add(line1);
@@ -157,8 +159,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
         lengthLabel1.setText("n=" + word1.length());
         lengthLabel2.setText("m=" + word2.length());
 
-        wordLabel1.setText(word1);
-        wordLabel2.setText(word2);
+        wordLabel1.setText("x=" + word1);
+        wordLabel2.setText("y=" + word2);
 
         canvas.setWord1(word1);
         canvas.setWord2(word2);

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -24,7 +24,8 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * @author danielaflores
+ * So much of this code is specific to LCSProblem, it might be worthwhile to
+ * write separate variable views for each problem type. -Gary 10/2025
  */
 public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
@@ -40,7 +41,7 @@ public class VariablesView extends GPanel implements ProblemListener {
 
     public void setModel(Problem model) {
         this.problem = model;
-        
+
         if (this.problem != null) {
             this.problem.addProblemListener(this);
         }
@@ -49,7 +50,6 @@ public class VariablesView extends GPanel implements ProblemListener {
     }
 
     private void initializeComponents() {
-        // These will need to vary by problem type
         rName = new JLabel("row = ");
         rValue = new JLabel();
         cName = new JLabel("col = ");
@@ -280,7 +280,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 ycName,
                 2,
@@ -310,7 +310,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 lcsName,
                 2,
@@ -356,7 +356,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 int lineNum = problem.getNextLineNumber();
                 String x = ((LCSProblem) problem).getX();
                 String y = ((LCSProblem) problem).getY();
-                
+
                 /*
                 -1 is a flag value that says "this variables is not in play right now",
                 so we will not display that
@@ -369,10 +369,10 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
                 String xrText;
                 String ycText;
-                
+
                 //-----------------------EXCEPTIONS-----------------------------
-                
-                // We want to see the chars when we're on the relevant line
+
+                // We want to see the chars, but only when we're on the relevant line
                 if (lineNum == 7) {
                     xrText = String.valueOf(x.charAt(i - 1));
                     ycText = String.valueOf(y.charAt(j - 1));
@@ -383,7 +383,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                     xrText = "";
                     ycText = "";
                 }
-                
+
                 // We want to see the while loop values before they are set
                 if (lineNum == 101) {
                     rText = String.valueOf(problem.getVariableValue("n") - 1);
@@ -395,15 +395,15 @@ public class VariablesView extends GPanel implements ProblemListener {
                 */
                 if (lineNum == 1) rText = String.valueOf(r);
                 if (lineNum == 3) {
-                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                    cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
                 if (lineNum == 5) {
-                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                    iText = (i == -1) ? String.valueOf(i + 1) : String.valueOf(i);
                 }
                 if (lineNum == 6) {
-                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                    jText = (j == -1) ? String.valueOf(j + 1) : String.valueOf(j);
                 }
-                
+
                 rValue.setText(rText);
                 cValue.setText(cText);
                 iValue.setText(iText);
@@ -413,6 +413,10 @@ public class VariablesView extends GPanel implements ProblemListener {
                 xrValue.setText(xrText);
                 ycValue.setText(ycText);
                 lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
+                
+                break;
+            default:
+                // Other problem types coming... soon?
         }
     }
 

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,6 +12,7 @@
  */
 package edu.regis.dptu.view;
 
+import edu.regis.dptu.model.LCSProblem;
 import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
@@ -20,15 +21,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemListener;
 
 /**
  * @author danielaflores
  */
-public class VariablesView extends GPanel {
+public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
 
-    private Problem model;
-    private JLabel rName, rValue, cName, cValue, iName, iValue, jName, jValue, lName, lValue;
+    private Problem problem;
+    private JLabel nName, nValue, mName, mValue, rName, rValue, cName, cValue, iName, iValue, 
+            jName, jValue, xrName, xrValue, ycName, ycValue, lcsName, lcsValue;
 
     public VariablesView() {
         initializeComponents();
@@ -36,28 +39,35 @@ public class VariablesView extends GPanel {
     }
 
     public void setModel(Problem model) {
-        this.model = model;
-
-        if (model != null) {
-            setVisible(true);
-        } else {
-            setVisible(false);
+        this.problem = model;
+        
+        if (this.problem != null) {
+            this.problem.addProblemListener(this);
         }
 
         updateView();
     }
 
     private void initializeComponents() {
-        rName = new JLabel("r = ");
-        rValue = new JLabel("");
-        cName = new JLabel("c = ");
-        cValue = new JLabel("");
+        // These will need to vary by problem type
+        rName = new JLabel("row = ");
+        rValue = new JLabel();
+        cName = new JLabel("col = ");
+        cValue = new JLabel();
         jName = new JLabel("j = ");
-        jValue = new JLabel("");
+        jValue = new JLabel();
         iName = new JLabel("i = ");
-        iValue = new JLabel("");
-        lName = new JLabel("l = ");
-        lValue = new JLabel("");
+        iValue = new JLabel();
+        nName = new JLabel("n = ");
+        nValue = new JLabel();
+        mName = new JLabel("m = ");
+        mValue = new JLabel();
+        xrName = new JLabel("x[row] = ");
+        xrValue = new JLabel();
+        ycName = new JLabel("y[col] = ");
+        ycValue = new JLabel();
+        lcsName = new JLabel("lcs = ");
+        lcsValue = new JLabel();
     }
 
     private void layoutComponents() {
@@ -69,7 +79,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -99,7 +109,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -129,7 +139,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -159,7 +169,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -182,8 +192,23 @@ public class VariablesView extends GPanel {
                 5);
 
         addc(
-                lName,
+                nName,
                 0,
+                4,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                nValue,
+                1,
                 4,
                 1,
                 1,
@@ -197,9 +222,114 @@ public class VariablesView extends GPanel {
                 5);
 
         addc(
-                lValue,
+                mName,
+                0,
+                5,
                 1,
-                4,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                mValue,
+                1,
+                5,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                xrName,
+                2,
+                0,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                xrValue,
+                3,
+                0,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+        
+        addc(
+                ycName,
+                2,
+                1,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                ycValue,
+                3,
+                1,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+        
+        addc(
+                lcsName,
+                2,
+                2,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                lcsValue,
+                3,
+                2,
                 1,
                 1,
                 0.0,
@@ -213,20 +343,81 @@ public class VariablesView extends GPanel {
     }
 
     private void updateView() {
-        if (model == null) {
+        if (problem == null) {
             return;
         }
 
-        // Here you would update the variable labels based on the model
-        // For example, if model is an LCSProblem:
-        /*
-        if (model instanceof LCSProblem) {
-            LCSProblem lcsProblem = (LCSProblem) model;
-            rValue.setText(String.valueOf(lcsProblem.getR()));
-            cValue.setText(String.valueOf(lcsProblem.getC()));
-            iValue.setText(String.valueOf(lcsProblem.getI()));
-            jValue.setText(String.valueOf(lcsProblem.getJ()));
+        switch(problem.getType()) {
+            case LCS_PROBLEM:
+                int r = problem.getVariableValue("r");
+                int c = problem.getVariableValue("c");
+                int i = problem.getVariableValue("i");
+                int j = problem.getVariableValue("j");
+                int lineNum = problem.getNextLineNumber();
+                String x = ((LCSProblem) problem).getX();
+                String y = ((LCSProblem) problem).getY();
+                
+                /*
+                -1 is a flag value that says "this variables is not in play right now",
+                so we will not display that
+                Also, the table starts with -1, but Java arrays start with 0, so we
+                must adjust
+                */
+                String rText = (r > -1) ? String.valueOf(problem.getVariableValue("r") - 1) : "";
+                String cText = (c > -1) ? String.valueOf(problem.getVariableValue("c") - 1) : "";
+                String iText = (i > -1) ? String.valueOf(problem.getVariableValue("i") - 1) : "";
+                String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
+                String xrText;
+                String ycText;
+                
+                //-----------------------EXCEPTIONS-----------------------------
+                
+                // We want to see the chars when we're on the relevant line
+                if (lineNum == 7) {
+                    xrText = String.valueOf(x.charAt(i - 1));
+                    ycText = String.valueOf(y.charAt(j - 1));
+                } else if (lineNum == 103 || lineNum == 104) {
+                    xrText = String.valueOf(x.charAt(r - 1));
+                    ycText = String.valueOf(y.charAt(c - 1));
+                } else {
+                    xrText = "";
+                    ycText = "";
+                }
+                
+                // We want to see the while loop values before they are set
+                if (lineNum == 101) {
+                    rText = String.valueOf(problem.getVariableValue("n") - 1);
+                    cText = String.valueOf(problem.getVariableValue("m") - 1);
+                }
+
+                /*
+                We want the for loops to display their variable's value before it is set
+                */
+                if (lineNum == 1) rText = String.valueOf(r);
+                if (lineNum == 3) {
+                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                }
+                if (lineNum == 5) {
+                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                }
+                if (lineNum == 6) {
+                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                }
+                
+                rValue.setText(rText);
+                cValue.setText(cText);
+                iValue.setText(iText);
+                jValue.setText(jText);
+                nValue.setText(String.valueOf(x.length()));
+                mValue.setText(String.valueOf(y.length()));
+                xrValue.setText(xrText);
+                ycValue.setText(ycText);
+                lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
         }
-        */
+    }
+
+    @Override
+    public void problemUpdated(Problem model) {
+        updateView();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -24,8 +24,8 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * So much of this code is specific to LCSProblem, it might be worthwhile to
- * write separate variable views for each problem type. -Gary 10/2025
+ * So much of this code is specific to LCSProblem, it might be worthwhile to write separate variable
+ * views for each problem type. -Gary 10/2025
  */
 public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
@@ -386,7 +386,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String xrText;
                 String ycText;
 
-                //-----------------------EXCEPTIONS-----------------------------
+                // -----------------------EXCEPTIONS-----------------------------
 
                 // We want to see the chars, but only when we're on the relevant line
 
@@ -430,7 +430,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 xrValue.setText(xrText);
                 ycValue.setText(ycText);
                 lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
-                
+
                 break;
             default:
                 // Other problem types coming... soon?

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,7 +12,6 @@
  */
 package edu.regis.dptu.view;
 
-import edu.regis.dptu.model.LCSProblem;
 import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
@@ -20,6 +19,7 @@ import javax.swing.JLabel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -30,8 +30,24 @@ public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
 
     private Problem problem;
-    private JLabel nName, nValue, mName, mValue, rName, rValue, cName, cValue, iName, iValue, 
-            jName, jValue, xrName, xrValue, ycName, ycValue, lcsName, lcsValue;
+    private JLabel nName,
+            nValue,
+            mName,
+            mValue,
+            rName,
+            rValue,
+            cName,
+            cValue,
+            iName,
+            iValue,
+            jName,
+            jValue,
+            xrName,
+            xrValue,
+            ycName,
+            ycValue,
+            lcsName,
+            lcsValue;
 
     public VariablesView() {
         initializeComponents();
@@ -40,7 +56,7 @@ public class VariablesView extends GPanel implements ProblemListener {
 
     public void setModel(Problem model) {
         this.problem = model;
-        
+
         if (this.problem != null) {
             this.problem.addProblemListener(this);
         }
@@ -280,7 +296,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 ycName,
                 2,
@@ -310,7 +326,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 lcsName,
                 2,
@@ -347,7 +363,7 @@ public class VariablesView extends GPanel implements ProblemListener {
             return;
         }
 
-        switch(problem.getType()) {
+        switch (problem.getType()) {
             case LCS_PROBLEM:
                 int r = problem.getVariableValue("r");
                 int c = problem.getVariableValue("c");
@@ -356,7 +372,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 int lineNum = problem.getNextLineNumber();
                 String x = ((LCSProblem) problem).getX();
                 String y = ((LCSProblem) problem).getY();
-                
+
                 /*
                 -1 is a flag value that says "this variables is not in play right now",
                 so we will not display that
@@ -369,9 +385,9 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
                 String xrText;
                 String ycText;
-                
-                //-----------------------EXCEPTIONS-----------------------------
-                
+
+                // -----------------------EXCEPTIONS-----------------------------
+
                 // We want to see the chars when we're on the relevant line
                 if (lineNum == 7) {
                     xrText = String.valueOf(x.charAt(i - 1));
@@ -383,7 +399,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                     xrText = "";
                     ycText = "";
                 }
-                
+
                 // We want to see the while loop values before they are set
                 if (lineNum == 101) {
                     rText = String.valueOf(problem.getVariableValue("n") - 1);
@@ -395,15 +411,15 @@ public class VariablesView extends GPanel implements ProblemListener {
                 */
                 if (lineNum == 1) rText = String.valueOf(r);
                 if (lineNum == 3) {
-                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                    cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
                 if (lineNum == 5) {
-                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                    iText = (i == -1) ? String.valueOf(i + 1) : String.valueOf(i);
                 }
                 if (lineNum == 6) {
-                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                    jText = (j == -1) ? String.valueOf(j + 1) : String.valueOf(j);
                 }
-                
+
                 rValue.setText(rText);
                 cValue.setText(cText);
                 iValue.setText(iText);


### PR DESCRIPTION
I suggest setting RUN_STEP_INTERVAL in Problem.java to 0 for fast run throughs.

### GPanel.java
Fixed row/col mixup

### LCSProblem.java
added a variable currentLCS so VariablesView can display the solution as it forms.

### SubSequenceView.java
corrected variables

### VariablesView.java
made VariablesView a ProblemListener so it can register for updates.
Added several new variables: n and m (the length of the strings), xr and yc (to display the values of the characters being compared at certain points), lcs.
I'm also planning on reusing row and column for lines 6-11 in a future pr and removing variables i and j entirely.
updateView() sets the strings to their appropriate values. This required several weird exceptions. The logic I am following is that at any point, the code highlighted is the line of code that will execute when you click the "step" button. Therefore, the variables should display what the variables' values will be when that step is executed. This does not always match what their values are in LCSProblem. I may address this in a future pr, but it might be more trouble than it's worth.
The other issue is that this class has so much code that is specific to LCSProblem that it may be better to have 3 separate variable views based on problem type, but that will have to wait until the other problem types are implemented.