### PR TITLE
Dptu 94 Rewrite LCSProblem for VariablesView

### DIFF
--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -67,10 +67,8 @@ public class LCSProblem extends Problem {
 
     /** Input sequence 2. (Stored in variables map) */
     private final String y; // Keep original field if needed
-    
-    /**
-     * This keeps track of the lcs as determined by the backtracking algorithm
-     */
+
+    /** This keeps track of the lcs as determined by the backtracking algorithm */
     private String currentLcs = "";
 
     /**
@@ -142,7 +140,7 @@ public class LCSProblem extends Problem {
     public String getY() {
         return y;
     }
-    
+
     public String getCurrentLcs() {
         return currentLcs;
     }

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -114,8 +114,6 @@ public class LCSProblem extends Problem {
         variables.put("m", m);
         variables.put("r", -1);
         variables.put("c", -1);
-        variables.put("i", -1);
-        variables.put("j", -1);
         // The DP table
         variables.put("l", new int[n + 1][m + 1]);
         // An internal table to keep track of highlighting for backtracking
@@ -159,7 +157,7 @@ public class LCSProblem extends Problem {
         return executionState;
     }
 
-    /** Initialize the DP table with -1 (or another indicator of uncomputed) */
+    /** Initialize the DP table with -1 (or another indicator of un-computed) */
     private void initializeTable() {
         int[][] initialTable = (int[][]) variables.get(tableVariable);
         for (int row = 0; row <= x.length(); row++) {
@@ -273,8 +271,6 @@ public class LCSProblem extends Problem {
         nextLineNumber = 0;
         variables.put("r", -1);
         variables.put("c", -1);
-        variables.put("i", -1);
-        variables.put("j", -1);
 
         initializeTable();
         initializeBacktrackingTable();
@@ -303,15 +299,15 @@ public class LCSProblem extends Problem {
         codeStatements.add(
                 "<html><pre>  <b>for</b> col = 0 to m-1 <b>do</b></pre></html>"); // Line 3
         codeStatements.add("<html><pre>    L[-1,col] = 0</pre></html>"); // Line 4
-        codeStatements.add("<html><pre>  <b>for</b> i = 0 to n-1 <b>do</b></pre></html>"); // Line 5
+        codeStatements.add("<html><pre>  <b>for</b> row = 0 to n-1 <b>do</b></pre></html>"); // Line 5
         codeStatements.add(
-                "<html><pre>    <b>for</b> j = 0 to m-1 <b>do</b></pre></html>"); // Line 6
+                "<html><pre>    <b>for</b> col = 0 to m-1 <b>do</b></pre></html>"); // Line 6
         codeStatements.add(
-                "<html><pre>      <b>if</b> x<sub>i</sub> == y<sub>j</sub> <b>then</b></pre></html>"); // Line 7
-        codeStatements.add("<html><pre>        L[i, j] = L[i-1, j-1] + 1</pre></html>"); // Line 8
+                "<html><pre>      <b>if</b> x[row] == y[col] <b>then</b></pre></html>"); // Line 7
+        codeStatements.add("<html><pre>        L[row, col] = L[row-1, col-1] + 1</pre></html>"); // Line 8
         codeStatements.add("<html><pre>      <b>else</b></pre></html>"); // Line 9
         codeStatements.add(
-                "<html><pre>        L[i, j] = max(L[i-1, j], L[i, j-1])</pre></html>"); // Line 10
+                "<html><pre>        L[row, col] = max(L[row-1, col], L[row, col-1])</pre></html>"); // Line 10
         codeStatements.add("<html><pre>  <b>return</b> L</pre></html>"); // Line 11
     }
 
@@ -350,10 +346,6 @@ public class LCSProblem extends Problem {
                 java.util.logging.Level.INFO, "r (array idx): " + variables.get("r"));
         LCSProblem.julLogger.log(
                 java.util.logging.Level.INFO, "c (array idx): " + variables.get("c"));
-        LCSProblem.julLogger.log(
-                java.util.logging.Level.INFO, "i (array idx): " + variables.get("i"));
-        LCSProblem.julLogger.log(
-                java.util.logging.Level.INFO, "j (array idx): " + variables.get("j"));
 
         int n = (int) variables.get("n");
         int m = (int) variables.get("m");
@@ -378,8 +370,8 @@ public class LCSProblem extends Problem {
         LCSProblem.julLogger.log(java.util.logging.Level.INFO, "------------------------");
     }
 
-    // -----------------------LCS Algorithm--------------------------------------
-    // --------------------------------------------------------------------------
+    // -----------------------LCS Algorithm-------------------------------------
+    // -------------------------------------------------------------------------
 
     /** LCS(x,y) - Line 0 (Implicit start) */
     public void executeLine0() {
@@ -471,103 +463,103 @@ public class LCSProblem extends Problem {
         nextLineNumber = 3; // Go back to check c loop condition
     }
 
-    /** for i = 0 to n-1 do (DP indices) -> for i = 1 to n (Array indices) Line 5 */
+    /** for row = 0 to n-1 do (DP indices) -> for row = 1 to n (Array indices) Line 5 */
     public void executeLine5() {
-        int i = (int) variables.get("i");
+        int r = (int) variables.get("r");
 
-        if (i == -1) { // First entry
-            i = 1; // Start array index i at 1 (DP index 0)
-            variables.put("i", i);
+        if (r == -1) { // First entry
+            r = 1; // Start array index row at 1 (DP index 0)
+            variables.put("r", r);
             executionState = EXECUTION_STATE.J_LOOP;
-            nextLineNumber = 6; // Enter j loop
+            nextLineNumber = 6; // Enter col loop (j loop)
         } else { // Subsequent iterations
-            i++; // Increment i (array index)
-            variables.put("i", i);
+            r++; // Increment row (array index)
+            variables.put("r", r);
             int n = (int) variables.get("n");
 
-            if (i == n + 1) { // Check boundary (array index up to n)
-                // Finished i loop
+            if (r == n + 1) { // Check boundary (array index up to n)
+                // Finished row loop
                 nextLineNumber = 11; // Go to return statement
                 executionState = EXECUTION_STATE.RETRN;
-                variables.put("i", -1); // Reset i
+                variables.put("r", -1); // Reset row
             } else {
-                // Continue i loop, reset j loop for the new i
-                nextLineNumber = 6; // Re-enter j loop
+                // Continue row loop, reset col loop for the new row
+                nextLineNumber = 6; // Re-enter col loop
                 executionState = EXECUTION_STATE.J_LOOP;
             }
         }
     }
 
-    /** for j = 0 to m-1 do (DP indices) -> for j = 1 to m (Array indices) Line 6 */
+    /** for col = 0 to m-1 do (DP indices) -> for col = 1 to m (Array indices) Line 6 */
     public void executeLine6() {
-        int j = (int) variables.get("j");
+        int c = (int) variables.get("c");
 
-        if (j == -1) { // First entry for current i
-            j = 1; // Start array index j at 1 (DP index 0)
-            variables.put("j", j);
+        if (c == -1) { // First entry for current row
+            c = 1; // Start array index col at 1 (DP index 0)
+            variables.put("c", c);
             nextLineNumber = 7; // Go to 'if' statement
-        } else { // Subsequent iterations for current i
-            j++; // Increment j (array index)
-            variables.put("j", j);
+        } else { // Subsequent iterations for current row
+            c++; // Increment col (array index)
+            variables.put("c", c);
             int m = (int) variables.get("m");
 
-            if (j == m + 1) { // Check boundary (array index up to m)
-                // Finished j loop for current i
-                nextLineNumber = 5; // Go back to outer i loop
+            if (c == m + 1) { // Check boundary (array index up to m)
+                // Finished col loop for current row
+                nextLineNumber = 5; // Go back to outer row loop
                 executionState = EXECUTION_STATE.I_LOOP; // Back to outer loop state
-                variables.put("j", -1); // Reset j
+                variables.put("c", -1); // Reset col
             } else {
-                // Continue j loop
+                // Continue col loop
                 nextLineNumber = 7; // Go back to 'if' statement
             }
         }
     }
 
-    /** Line 7: if x[i] == y[j] (DP indices) -> if x[i-1] == y[j-1] (String/Array indices) */
+    /** Line 7: if x[row] == y[col] (DP indices) -> if x[row-1] == y[col-1] (String/Array indices) */
     public void executeLine7() {
-        int i = (int) variables.get("i");
-        int j = (int) variables.get("j");
+        int r = (int) variables.get("r");
+        int c = (int) variables.get("c");
         String xStr = (String) variables.get("x");
         String yStr = (String) variables.get("y");
 
         // Adjust indices for 0-based String access
-        if (i > 0 && j > 0 && i <= xStr.length() && j <= yStr.length()) {
-            if (xStr.charAt(i - 1) == yStr.charAt(j - 1)) {
+        if (r > 0 && c > 0 && r <= xStr.length() && c <= yStr.length()) {
+            if (xStr.charAt(r - 1) == yStr.charAt(c - 1)) {
                 nextLineNumber = 8; // Match case
             } else {
                 nextLineNumber = 9; // No match case (line 9 is 'else')
             }
         } else {
             System.err.println(
-                    "ERROR: LCSProblem executeLine7 accessing String out of bounds: i="
-                            + i
-                            + ", j="
-                            + j);
-            nextLineNumber = 6; // Tentatively go back to j loop check
+                    "ERROR: LCSProblem executeLine7 accessing String out of bounds: r="
+                            + r
+                            + ", c="
+                            + c);
+            nextLineNumber = 6; // Tentatively go back to c loop check
         }
     }
 
     /**
-     * Line 8: L[i, j] = L[i-1, j-1] + 1 (DP indices) Maps to subproblem[i][j] =
-     * subproblem[i-1][j-1] + 1 (Array indices)
+     * Line 8: L[row, col] = L[row-1, col-1] + 1 (DP indices) Maps to subproblem[r][c] =
+     * subproblem[r-1][c-1] + 1 (Array indices)
      */
     public void executeLine8() {
         int[][] subproblemL = (int[][]) variables.get(tableVariable);
-        int i = (int) variables.get("i");
-        int j = (int) variables.get("j");
+        int r = (int) variables.get("r");
+        int c = (int) variables.get("c");
         // Bounds check for array access
         if (subproblemL != null
-                && i > 0
-                && j > 0
-                && i < subproblemL.length
-                && j < subproblemL[i].length) {
-            int newValue = subproblemL[i - 1][j - 1] + 1;
-            subproblemL[i][j] = newValue;
+                && r > 0
+                && c > 0
+                && r < subproblemL.length
+                && c < subproblemL[r].length) {
+            int newValue = subproblemL[r - 1][c - 1] + 1;
+            subproblemL[r][c] = newValue;
         } else {
             System.err.println(
-                    "ERROR: LCSProblem executeLine8 accessing out of bounds: i=" + i + ", j=" + j);
+                    "ERROR: LCSProblem executeLine8 accessing out of bounds: r=" + r + ", c=" + c);
         }
-        nextLineNumber = 6; // Go back to check j loop condition
+        nextLineNumber = 6; // Go back to check c loop condition
     }
 
     /** Line 9: else (No operation, just determines control flow) */
@@ -576,32 +568,32 @@ public class LCSProblem extends Problem {
     }
 
     /**
-     * Line 10: L[i, j] = max(L[i-1, j], L[i, j-1]) (DP indices) Maps to subproblem[i][j] =
-     * max(subproblem[i-1][j], subproblem[i][j-1]) (Array indices)
+     * Line 10: L[row, col] = max(L[row-1, col], L[row, col-1]) (DP indices) Maps to subproblem[r][c] =
+     * max(subproblem[r-1][c], subproblem[r][c-1]) (Array indices)
      */
     public void executeLine10() {
         int[][] subproblemL = (int[][]) variables.get(tableVariable);
-        int i = (int) variables.get("i");
-        int j = (int) variables.get("j");
+        int r = (int) variables.get("r");
+        int c = (int) variables.get("c");
         // Bounds check for array access
         if (subproblemL != null
-                && i > 0
-                && j > 0
-                && i < subproblemL.length
-                && j < subproblemL[i].length
-                && (i - 1) < subproblemL.length
-                && j < subproblemL[i - 1].length
-                && i < subproblemL.length
-                && (j - 1) < subproblemL[i].length) {
-            int valAbove = subproblemL[i - 1][j];
-            int valLeft = subproblemL[i][j - 1];
+                && r > 0
+                && c > 0
+                && r < subproblemL.length
+                && c < subproblemL[r].length
+                && (r - 1) < subproblemL.length
+                && c < subproblemL[r - 1].length
+                && r < subproblemL.length
+                && (c - 1) < subproblemL[r].length) {
+            int valAbove = subproblemL[r - 1][c];
+            int valLeft = subproblemL[r][c - 1];
             int newValue = Integer.max(valAbove, valLeft);
-            subproblemL[i][j] = newValue;
+            subproblemL[r][c] = newValue;
         } else {
             System.err.println(
-                    "ERROR: LCSProblem executeLine10 accessing out of bounds: i=" + i + ", j=" + j);
+                    "ERROR: LCSProblem executeLine10 accessing out of bounds: r=" + r + ", c=" + c);
         }
-        nextLineNumber = 6; // Go back to check j loop condition
+        nextLineNumber = 6; // Go back to check c loop condition
     }
 
     /** Line 11: return L */
@@ -617,9 +609,9 @@ public class LCSProblem extends Problem {
         }
     }
 
-    // ---------------------------LCS Algorithm Finished-------------------------
+    // ---------------------------LCS Algorithm Finished------------------------
 
-    // -----------------------Backtracking Algorithm Begins----------------------
+    // -----------------------Backtracking Algorithm Begins---------------------
 
     /**
      * Line: Backtrack(table) executionState has already been changed to B_PRE courtesy of the
@@ -745,9 +737,9 @@ public class LCSProblem extends Problem {
         executionState = EXECUTION_STATE.B_POST;
     }
 
-    // ---------------------Backtracking Finished--------------------------------
+    // ---------------------Backtracking Finished-------------------------------
 
-    // -----------------------------Undo-----------------------------------------
+    // -----------------------------Undo----------------------------------------
 
     /* method undo() in Problem.java handles resetting nextLineNumber and
     removing the last item from executionHistory
@@ -802,54 +794,54 @@ public class LCSProblem extends Problem {
         lTable[0][c] = -1; // -1 is the initial flag value
     }
 
-    /** Undoes executeLine5: for i = 0 to n-1 do */
+    /** Undoes executeLine5: for row = 0 to n-1 do */
     public void undoLine5() {
-        int i = (int) variables.get("i");
-        if (i == 1) { // First iteration goes back to initial flag value
-            i = -1;
+        int r = (int) variables.get("r");
+        if (r == 1) { // First iteration goes back to initial flag value
+            r = -1;
             executionState = EXECUTION_STATE.I_LOOP;
         }
-        // Last iteration returns to the i loop
+        // Last iteration returns to the r loop (i loop)
         else if (executionState == EXECUTION_STATE.RETRN) {
             executionState = EXECUTION_STATE.I_LOOP;
             int n = (int) variables.get("n");
-            i = n;
-        } else { // Other iterations just decrement i
-            i--;
+            r = n;
+        } else { // Other iterations just decrement row
+            r--;
             executionState = EXECUTION_STATE.I_LOOP;
         }
-        variables.put("i", i);
+        variables.put("r", r);
     }
 
-    /** Undoes executeLine6: for j = 0 to m-1 do */
+    /** Undoes executeLine6: for col = 0 to m-1 do */
     public void undoLine6() {
-        int j = (int) variables.get("j");
-        if (j == 1) { // First iteration goes back to initial flag value
-            j = -1;
+        int c = (int) variables.get("c");
+        if (c == 1) { // First iteration goes back to initial flag value
+            c = -1;
         }
-        // Last iteration returns to the j loop
+        // Last iteration returns to the col (j) loop
         else if (executionState == EXECUTION_STATE.I_LOOP) {
             executionState = EXECUTION_STATE.J_LOOP;
             int m = (int) variables.get("m");
-            j = m + 1;
-            j--;
-        } else { // Other iterations just decrement j
-            j--;
+            c = m + 1;
+            c--;
+        } else { // Other iterations just decrement col
+            c--;
         }
-        variables.put("j", j);
+        variables.put("c", c);
     }
 
-    /** Undoes executeLine7: if x[i] == y[j] */
+    /** Undoes executeLine7: if x[row] == y[col] */
     public void undoLine7() {
         // NOOP
     }
 
-    /** Undoes executeLine8: L[i,j] = L[i-1, j-1] + 1 */
+    /** Undoes executeLine8: L[row,col] = L[row-1, col-1] + 1 */
     public void undoLine8() {
-        int i = (int) variables.get("i");
-        int j = (int) variables.get("j");
+        int r = (int) variables.get("r");
+        int c = (int) variables.get("c");
         int[][] lTable = (int[][]) variables.get(tableVariable);
-        lTable[i][j] = -1; // Restore to flag value
+        lTable[r][c] = -1; // Restore to flag value
     }
 
     /** Undoes executeLine9: else */
@@ -857,12 +849,12 @@ public class LCSProblem extends Problem {
         // NOOP
     }
 
-    /** Undoes executeLine10: L[i, j] = max(L[i-1, j], L[i, j-1]) */
+    /** Undoes executeLine10: L[row, col] = max(L[row-1, col], L[row, col-1]) */
     public void undoLine10() {
-        int i = (int) variables.get("i");
-        int j = (int) variables.get("j");
+        int r = (int) variables.get("r");
+        int c = (int) variables.get("c");
         int[][] lTable = (int[][]) variables.get(tableVariable);
-        lTable[i][j] = -1; // Restore to flag value
+        lTable[r][c] = -1; // Restore to flag value
     }
 
     /** Undoes executeLine11: return L */
@@ -870,7 +862,7 @@ public class LCSProblem extends Problem {
         executionState = EXECUTION_STATE.RETRN;
     }
 
-    // ----------------------------Undo Backtracking-----------------------------
+    // ----------------------------Undo Backtracking----------------------------
 
     /** Undoes executeLine100: Backtrack(table) */
     public void undoLine100() {

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -299,12 +299,14 @@ public class LCSProblem extends Problem {
         codeStatements.add(
                 "<html><pre>  <b>for</b> col = 0 to m-1 <b>do</b></pre></html>"); // Line 3
         codeStatements.add("<html><pre>    L[-1,col] = 0</pre></html>"); // Line 4
-        codeStatements.add("<html><pre>  <b>for</b> row = 0 to n-1 <b>do</b></pre></html>"); // Line 5
+        codeStatements.add(
+                "<html><pre>  <b>for</b> row = 0 to n-1 <b>do</b></pre></html>"); // Line 5
         codeStatements.add(
                 "<html><pre>    <b>for</b> col = 0 to m-1 <b>do</b></pre></html>"); // Line 6
         codeStatements.add(
                 "<html><pre>      <b>if</b> x[row] == y[col] <b>then</b></pre></html>"); // Line 7
-        codeStatements.add("<html><pre>        L[row, col] = L[row-1, col-1] + 1</pre></html>"); // Line 8
+        codeStatements.add(
+                "<html><pre>        L[row, col] = L[row-1, col-1] + 1</pre></html>"); // Line 8
         codeStatements.add("<html><pre>      <b>else</b></pre></html>"); // Line 9
         codeStatements.add(
                 "<html><pre>        L[row, col] = max(L[row-1, col], L[row, col-1])</pre></html>"); // Line 10
@@ -515,7 +517,9 @@ public class LCSProblem extends Problem {
         }
     }
 
-    /** Line 7: if x[row] == y[col] (DP indices) -> if x[row-1] == y[col-1] (String/Array indices) */
+    /**
+     * Line 7: if x[row] == y[col] (DP indices) -> if x[row-1] == y[col-1] (String/Array indices)
+     */
     public void executeLine7() {
         int r = (int) variables.get("r");
         int c = (int) variables.get("c");
@@ -568,8 +572,8 @@ public class LCSProblem extends Problem {
     }
 
     /**
-     * Line 10: L[row, col] = max(L[row-1, col], L[row, col-1]) (DP indices) Maps to subproblem[r][c] =
-     * max(subproblem[r-1][c], subproblem[r][c-1]) (Array indices)
+     * Line 10: L[row, col] = max(L[row-1, col], L[row, col-1]) (DP indices) Maps to
+     * subproblem[r][c] = max(subproblem[r-1][c], subproblem[r][c-1]) (Array indices)
      */
     public void executeLine10() {
         int[][] subproblemL = (int[][]) variables.get(tableVariable);

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -49,8 +49,8 @@ public class LCSProblem extends Problem {
         PRE,
         R_LOOP,
         C_LOOP,
-        I_LOOP,
-        J_LOOP,
+        I_LOOP, // } These represent the nested
+        J_LOOP, // } for loop
         RETRN,
         POST,
         B_PRE,

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -67,6 +67,11 @@ public class LCSProblem extends Problem {
 
     /** Input sequence 2. (Stored in variables map) */
     private final String y; // Keep original field if needed
+    
+    /**
+     * This keeps track of the lcs as determined by the backtracking algorithm
+     */
+    private String currentLcs = "";
 
     /**
      * The current state of the algorithm, before the loops, in a loop, and after all of the loops
@@ -137,6 +142,10 @@ public class LCSProblem extends Problem {
     public String getY() {
         return y;
     }
+    
+    public String getCurrentLcs() {
+        return currentLcs;
+    }
 
     /**
      * {@inheritDoc}
@@ -173,6 +182,8 @@ public class LCSProblem extends Problem {
                 bTable[row][col] = -1;
             }
         }
+        // Since we're resetting the backtracking table, we also reset the lcs
+        currentLcs = "";
     }
 
     /**
@@ -312,7 +323,7 @@ public class LCSProblem extends Problem {
         backtrackingCodeStatements.add(
                 "<html><pre><b>BACKTRACK(table L)</b></pre></html>"); // line 0
         backtrackingCodeStatements.add(
-                "<html><pre>row = x.length - 1, col = y.length - 1</pre></html>"); // line 1
+                "<html><pre>row = n - 1, col = m - 1</pre></html>"); // line 1
         backtrackingCodeStatements.add(
                 "<html><pre>while(row >= 0 && col >= 0)</pre></html>"); // line 2
         backtrackingCodeStatements.add("<html><pre>  if (x[row] == y[col])</pre></html>"); // line 3
@@ -669,6 +680,7 @@ public class LCSProblem extends Problem {
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
         bTable[row][col] = ADD_TO_SOLUTION; // highlight in green
+        currentLcs = y.charAt(col - 1) + currentLcs;
         nextLineNumber = 105;
     }
 
@@ -899,6 +911,7 @@ public class LCSProblem extends Problem {
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
         bTable[row][col] = HIT; // highlight in yellow
+        currentLcs = currentLcs.substring(1);
     }
 
     /** Undoes executeLine105: row-- */

--- a/src/main/java/edu/regis/dptu/model/Problem.java
+++ b/src/main/java/edu/regis/dptu/model/Problem.java
@@ -99,10 +99,6 @@ public abstract class Problem extends TitledModel {
      */
     public abstract ProblemKind getType();
 
-    public int getNextLineNumber() {
-        return nextLineNumber;
-    }
-
     /**
      * Method that determines if the subclass has completed with either the dp algorithm or the
      * backtracking algorithm. Used to disable functionality in the UI
@@ -196,7 +192,7 @@ public abstract class Problem extends TitledModel {
         this.backtrackingCodeStatements = backtrackingStatements;
     }
 
-    public int getCurrentLineNumber() {
+    public int getNextLineNumber() {
         return nextLineNumber;
     }
 
@@ -204,8 +200,8 @@ public abstract class Problem extends TitledModel {
         return BACKTRACKING_START_NUM;
     }
 
-    public void setCurrentLineNumber(int currentLineNumber) {
-        this.nextLineNumber = currentLineNumber;
+    public void setNextLineNumber(int nextLineNumber) {
+        this.nextLineNumber = nextLineNumber;
     }
 
     public String getTableVariable() {

--- a/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
+++ b/src/main/java/edu/regis/dptu/view/BacktrackingCodeView.java
@@ -152,9 +152,9 @@ public class BacktrackingCodeView extends GPanel implements ProblemListener {
 
         // Highlight the current line if model and labels are valid
         if (model != null && backtrackingStatementJLabels != null) {
-            int currentLineNumber = model.getCurrentLineNumber() - model.getBacktrackingStartNum();
-            if (currentLineNumber >= 0 && currentLineNumber < backtrackingStatementJLabels.size()) {
-                JLabel currentLabel = backtrackingStatementJLabels.get(currentLineNumber);
+            int nextLineNumber = model.getNextLineNumber() - model.getBacktrackingStartNum();
+            if (nextLineNumber >= 0 && nextLineNumber < backtrackingStatementJLabels.size()) {
+                JLabel currentLabel = backtrackingStatementJLabels.get(nextLineNumber);
                 if (currentLabel != null) {
                     currentLabel.setBackground(Color.YELLOW);
                     currentLabel.setOpaque(true);

--- a/src/main/java/edu/regis/dptu/view/CodeView.java
+++ b/src/main/java/edu/regis/dptu/view/CodeView.java
@@ -176,9 +176,9 @@ public class CodeView extends GPanel implements ProblemListener {
 
         // Highlight the current line if model and labels are valid
         if (model != null && statementJLabels != null) {
-            int currentLineNumber = model.getCurrentLineNumber();
-            if (currentLineNumber >= 0 && currentLineNumber < statementJLabels.size()) {
-                JLabel currentLabel = statementJLabels.get(currentLineNumber);
+            int nextLineNumber = model.getNextLineNumber();
+            if (nextLineNumber >= 0 && nextLineNumber < statementJLabels.size()) {
+                JLabel currentLabel = statementJLabels.get(nextLineNumber);
                 if (currentLabel != null) {
                     currentLabel.setBackground(Color.YELLOW);
                     currentLabel.setOpaque(true);

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -44,8 +44,8 @@ public class GPanel extends JPanel {
      * &nbsp;&nbsp; GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH, &nbsp;&nbsp; 5,5,5,5);
      *
      * @param c the child component
-     * @param gridX the row in which the child component is anchored
-     * @param gridY the column in which the child component is anchored
+     * @param gridX the column in which the child component is anchored
+     * @param gridY the row in which the child component is anchored
      * @param gridWidth the rows spanned by the child component in the bag
      * @param gridHeight the cols spanned by the child component in the bag
      * @param weightx the amount of width scaling during panel expansion
@@ -59,8 +59,8 @@ public class GPanel extends JPanel {
      */
     public void addc(
             Component c,
-            int gridX,
-            int gridY,
+            int gridX, // column
+            int gridY, // row
             int gridWidth,
             int gridHeight,
             double weightx,

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -212,7 +212,7 @@ public class StepViewPanel extends GPanel implements ProblemListener {
 
         // Status label (assuming this was added and is desired)
         statusLabel = new JLabel("Ready");
-        statusLabel.setFont(new Font("Dialog", Font.BOLD, 12)); // Default style
+        statusLabel.setFont(new Font("Monospaced", Font.BOLD, 12)); // Default style
     }
 
     /** Layout the child components in this panel. */
@@ -354,8 +354,8 @@ public class StepViewPanel extends GPanel implements ProblemListener {
                 statusLabel.setText("Finished!");
             } else {
                 int displayNum =
-                        (model.getCurrentLineNumber() % model.getBacktrackingStartNum()) + 1;
-                statusLabel.setText("Line: " + displayNum);
+                        (model.getNextLineNumber() % model.getBacktrackingStartNum()) + 1;
+                statusLabel.setText(" Line: " + String.format("%2d", displayNum));
             }
         } else {
             statusLabel.setText("No model loaded");

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -353,8 +353,7 @@ public class StepViewPanel extends GPanel implements ProblemListener {
             if (model.hasFinished()) {
                 statusLabel.setText("Finished!");
             } else {
-                int displayNum =
-                        (model.getNextLineNumber() % model.getBacktrackingStartNum()) + 1;
+                int displayNum = (model.getNextLineNumber() % model.getBacktrackingStartNum()) + 1;
                 statusLabel.setText(" Line: " + String.format("%2d", displayNum));
             }
         } else {

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -69,10 +69,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
         titleLabel.setFont(new Font("Segoe UI", Font.BOLD, 18));
         titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
-        lengthLabel1 = new JLabel("x=");
+        lengthLabel1 = new JLabel();
         lengthLabel1.setFont(new Font("Arial", Font.PLAIN, 16));
 
-        lengthLabel2 = new JLabel("y=");
+        lengthLabel2 = new JLabel();
         lengthLabel2.setFont(new Font("Arial", Font.PLAIN, 16));
 
         stepButton = new JButton("Step LCS");
@@ -154,8 +154,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
      */
     public void updateWords(String word1, String word2) {
         // Update lengths
-        lengthLabel1.setText("x=" + word1.length());
-        lengthLabel2.setText("y=" + word2.length());
+        lengthLabel1.setText("n=" + word1.length());
+        lengthLabel2.setText("m=" + word2.length());
 
         wordLabel1.setText(word1);
         wordLabel2.setText(word2);

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -70,10 +70,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
         titleLabel.setHorizontalAlignment(SwingConstants.CENTER);
 
         lengthLabel1 = new JLabel();
-        lengthLabel1.setFont(new Font("Arial", Font.PLAIN, 16));
+        lengthLabel1.setFont(new Font("Dialog", Font.PLAIN, 16));
 
         lengthLabel2 = new JLabel();
-        lengthLabel2.setFont(new Font("Arial", Font.PLAIN, 16));
+        lengthLabel2.setFont(new Font("Dialog", Font.PLAIN, 16));
 
         stepButton = new JButton("Step LCS");
         stepButton.addActionListener(e -> stepThroughLCS());
@@ -97,6 +97,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
         JPanel line1 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line1.add(lengthLabel1);
         wordLabel1 = new JLabel();
+        wordLabel1.setFont(new Font("Dialog", Font.PLAIN, 16));
         line1.add(wordLabel1);
 
         // Changed (April 17, 2025 - EverettCV): Now loads default value of the second variable
@@ -104,6 +105,7 @@ class SubSequenceView extends JPanel implements ProblemListener {
         JPanel line2 = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
         line2.add(lengthLabel2);
         wordLabel2 = new JLabel();
+        wordLabel2.setFont(new Font("Dialog", Font.PLAIN, 16));
         line2.add(wordLabel2);
 
         wordPanel.add(line1);
@@ -157,8 +159,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
         lengthLabel1.setText("n=" + word1.length());
         lengthLabel2.setText("m=" + word2.length());
 
-        wordLabel1.setText(word1);
-        wordLabel2.setText(word2);
+        wordLabel1.setText("x=" + word1);
+        wordLabel2.setText("y=" + word2);
 
         canvas.setWord1(word1);
         canvas.setWord2(word2);

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -261,7 +261,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
      */
     private void buildColumnHeaders(String string) {
         List<String> headers = new ArrayList<String>();
-        headers.add("(i,j)"); // Top-left corner label
+        headers.add("table"); // Top-left corner label
         headers.add("-1"); // Base case column
         for (int i = 0; i < string.length(); i++) {
             // HTML formatting to center label and index

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -39,10 +39,6 @@ public class VariablesView extends GPanel implements ProblemListener {
             rValue,
             cName,
             cValue,
-            iName,
-            iValue,
-            jName,
-            jValue,
             xrName,
             xrValue,
             ycName,
@@ -70,10 +66,6 @@ public class VariablesView extends GPanel implements ProblemListener {
         rValue = new JLabel();
         cName = new JLabel("col = ");
         cValue = new JLabel();
-        jName = new JLabel("j = ");
-        jValue = new JLabel();
-        iName = new JLabel("i = ");
-        iValue = new JLabel();
         nName = new JLabel("n = ");
         nValue = new JLabel();
         mName = new JLabel("m = ");
@@ -148,69 +140,9 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5);
 
         addc(
-                iName,
-                0,
-                2,
-                1,
-                1,
-                0.0,
-                0.0,
-                GridBagConstraints.NORTHEAST,
-                GridBagConstraints.NONE,
-                5,
-                5,
-                5,
-                5);
-
-        addc(
-                iValue,
-                1,
-                2,
-                1,
-                1,
-                0.0,
-                0.0,
-                GridBagConstraints.NORTHWEST,
-                GridBagConstraints.NONE,
-                5,
-                5,
-                5,
-                5);
-
-        addc(
-                jName,
-                0,
-                3,
-                1,
-                1,
-                0.0,
-                0.0,
-                GridBagConstraints.NORTHEAST,
-                GridBagConstraints.NONE,
-                5,
-                5,
-                5,
-                5);
-
-        addc(
-                jValue,
-                1,
-                3,
-                1,
-                1,
-                0.0,
-                0.0,
-                GridBagConstraints.NORTHWEST,
-                GridBagConstraints.NONE,
-                5,
-                5,
-                5,
-                5);
-
-        addc(
                 nName,
                 0,
-                4,
+                2,
                 1,
                 1,
                 0.0,
@@ -225,7 +157,7 @@ public class VariablesView extends GPanel implements ProblemListener {
         addc(
                 nValue,
                 1,
-                4,
+                2,
                 1,
                 1,
                 0.0,
@@ -240,7 +172,7 @@ public class VariablesView extends GPanel implements ProblemListener {
         addc(
                 mName,
                 0,
-                5,
+                3,
                 1,
                 1,
                 0.0,
@@ -255,7 +187,7 @@ public class VariablesView extends GPanel implements ProblemListener {
         addc(
                 mValue,
                 1,
-                5,
+                3,
                 1,
                 1,
                 0.0,
@@ -367,11 +299,13 @@ public class VariablesView extends GPanel implements ProblemListener {
             case LCS_PROBLEM:
                 int r = problem.getVariableValue("r");
                 int c = problem.getVariableValue("c");
-                int i = problem.getVariableValue("i");
-                int j = problem.getVariableValue("j");
                 int lineNum = problem.getNextLineNumber();
                 String x = ((LCSProblem) problem).getX();
                 String y = ((LCSProblem) problem).getY();
+                String rText;
+                String cText;
+                String xrText;
+                String ycText;
 
                 /*
                 -1 is a flag value that says "this variables is not in play right now",
@@ -379,21 +313,14 @@ public class VariablesView extends GPanel implements ProblemListener {
                 Also, the table starts with -1, but Java arrays start with 0, so we
                 must adjust
                 */
-                String rText = (r > -1) ? String.valueOf(problem.getVariableValue("r") - 1) : "";
-                String cText = (c > -1) ? String.valueOf(problem.getVariableValue("c") - 1) : "";
-                String iText = (i > -1) ? String.valueOf(problem.getVariableValue("i") - 1) : "";
-                String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
-                String xrText;
-                String ycText;
+                rText = (r > -1) ? String.valueOf(problem.getVariableValue("r") - 1) : "";
+                cText = (c > -1) ? String.valueOf(problem.getVariableValue("c") - 1) : "";
 
-                // -----------------------EXCEPTIONS-----------------------------
+                // -----------------------EXCEPTIONS----------------------------
 
                 // We want to see the chars, but only when we're on the relevant line
 
-                if (lineNum == 7) {
-                    xrText = String.valueOf(x.charAt(i - 1));
-                    ycText = String.valueOf(y.charAt(j - 1));
-                } else if (lineNum == 103 || lineNum == 104) {
+                if (lineNum == 7 || lineNum == 103 || lineNum == 104) {
                     xrText = String.valueOf(x.charAt(r - 1));
                     ycText = String.valueOf(y.charAt(c - 1));
                 } else {
@@ -415,16 +342,14 @@ public class VariablesView extends GPanel implements ProblemListener {
                     cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
                 if (lineNum == 5) {
-                    iText = (i == -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                    rText = (r == -1) ? String.valueOf(r + 1) : String.valueOf(r);
                 }
                 if (lineNum == 6) {
-                    jText = (j == -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                    cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
 
                 rValue.setText(rText);
                 cValue.setText(cText);
-                iValue.setText(iText);
-                jValue.setText(jText);
                 nValue.setText(String.valueOf(x.length()));
                 mValue.setText(String.valueOf(y.length()));
                 xrValue.setText(xrText);

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -24,7 +24,8 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * @author danielaflores
+ * So much of this code is specific to LCSProblem, it might be worthwhile to
+ * write separate variable views for each problem type. -Gary 10/2025
  */
 public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
@@ -40,7 +41,7 @@ public class VariablesView extends GPanel implements ProblemListener {
 
     public void setModel(Problem model) {
         this.problem = model;
-        
+
         if (this.problem != null) {
             this.problem.addProblemListener(this);
         }
@@ -49,7 +50,6 @@ public class VariablesView extends GPanel implements ProblemListener {
     }
 
     private void initializeComponents() {
-        // These will need to vary by problem type
         rName = new JLabel("row = ");
         rValue = new JLabel();
         cName = new JLabel("col = ");
@@ -280,7 +280,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 ycName,
                 2,
@@ -310,7 +310,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 lcsName,
                 2,
@@ -356,7 +356,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 int lineNum = problem.getNextLineNumber();
                 String x = ((LCSProblem) problem).getX();
                 String y = ((LCSProblem) problem).getY();
-                
+
                 /*
                 -1 is a flag value that says "this variables is not in play right now",
                 so we will not display that
@@ -369,10 +369,10 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
                 String xrText;
                 String ycText;
-                
+
                 //-----------------------EXCEPTIONS-----------------------------
-                
-                // We want to see the chars when we're on the relevant line
+
+                // We want to see the chars, but only when we're on the relevant line
                 if (lineNum == 7) {
                     xrText = String.valueOf(x.charAt(i - 1));
                     ycText = String.valueOf(y.charAt(j - 1));
@@ -383,7 +383,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                     xrText = "";
                     ycText = "";
                 }
-                
+
                 // We want to see the while loop values before they are set
                 if (lineNum == 101) {
                     rText = String.valueOf(problem.getVariableValue("n") - 1);
@@ -395,15 +395,15 @@ public class VariablesView extends GPanel implements ProblemListener {
                 */
                 if (lineNum == 1) rText = String.valueOf(r);
                 if (lineNum == 3) {
-                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                    cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
                 if (lineNum == 5) {
-                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                    iText = (i == -1) ? String.valueOf(i + 1) : String.valueOf(i);
                 }
                 if (lineNum == 6) {
-                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                    jText = (j == -1) ? String.valueOf(j + 1) : String.valueOf(j);
                 }
-                
+
                 rValue.setText(rText);
                 cValue.setText(cText);
                 iValue.setText(iText);
@@ -413,6 +413,10 @@ public class VariablesView extends GPanel implements ProblemListener {
                 xrValue.setText(xrText);
                 ycValue.setText(ycText);
                 lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
+                
+                break;
+            default:
+                // Other problem types coming... soon?
         }
     }
 

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,6 +12,7 @@
  */
 package edu.regis.dptu.view;
 
+import edu.regis.dptu.model.LCSProblem;
 import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
@@ -20,15 +21,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemListener;
 
 /**
  * @author danielaflores
  */
-public class VariablesView extends GPanel {
+public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
 
-    private Problem model;
-    private JLabel rName, rValue, cName, cValue, iName, iValue, jName, jValue, lName, lValue;
+    private Problem problem;
+    private JLabel nName, nValue, mName, mValue, rName, rValue, cName, cValue, iName, iValue, 
+            jName, jValue, xrName, xrValue, ycName, ycValue, lcsName, lcsValue;
 
     public VariablesView() {
         initializeComponents();
@@ -36,28 +39,35 @@ public class VariablesView extends GPanel {
     }
 
     public void setModel(Problem model) {
-        this.model = model;
-
-        if (model != null) {
-            setVisible(true);
-        } else {
-            setVisible(false);
+        this.problem = model;
+        
+        if (this.problem != null) {
+            this.problem.addProblemListener(this);
         }
 
         updateView();
     }
 
     private void initializeComponents() {
-        rName = new JLabel("r = ");
-        rValue = new JLabel("");
-        cName = new JLabel("c = ");
-        cValue = new JLabel("");
+        // These will need to vary by problem type
+        rName = new JLabel("row = ");
+        rValue = new JLabel();
+        cName = new JLabel("col = ");
+        cValue = new JLabel();
         jName = new JLabel("j = ");
-        jValue = new JLabel("");
+        jValue = new JLabel();
         iName = new JLabel("i = ");
-        iValue = new JLabel("");
-        lName = new JLabel("l = ");
-        lValue = new JLabel("");
+        iValue = new JLabel();
+        nName = new JLabel("n = ");
+        nValue = new JLabel();
+        mName = new JLabel("m = ");
+        mValue = new JLabel();
+        xrName = new JLabel("x[row] = ");
+        xrValue = new JLabel();
+        ycName = new JLabel("y[col] = ");
+        ycValue = new JLabel();
+        lcsName = new JLabel("lcs = ");
+        lcsValue = new JLabel();
     }
 
     private void layoutComponents() {
@@ -69,7 +79,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -99,7 +109,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -129,7 +139,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -159,7 +169,7 @@ public class VariablesView extends GPanel {
                 1,
                 0.0,
                 0.0,
-                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NORTHEAST,
                 GridBagConstraints.NONE,
                 5,
                 5,
@@ -182,8 +192,23 @@ public class VariablesView extends GPanel {
                 5);
 
         addc(
-                lName,
+                nName,
                 0,
+                4,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                nValue,
+                1,
                 4,
                 1,
                 1,
@@ -197,9 +222,114 @@ public class VariablesView extends GPanel {
                 5);
 
         addc(
-                lValue,
+                mName,
+                0,
+                5,
                 1,
-                4,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                mValue,
+                1,
+                5,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                xrName,
+                2,
+                0,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                xrValue,
+                3,
+                0,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+        
+        addc(
+                ycName,
+                2,
+                1,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                ycValue,
+                3,
+                1,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHWEST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+        
+        addc(
+                lcsName,
+                2,
+                2,
+                1,
+                1,
+                0.0,
+                0.0,
+                GridBagConstraints.NORTHEAST,
+                GridBagConstraints.NONE,
+                5,
+                5,
+                5,
+                5);
+
+        addc(
+                lcsValue,
+                3,
+                2,
                 1,
                 1,
                 0.0,
@@ -213,20 +343,81 @@ public class VariablesView extends GPanel {
     }
 
     private void updateView() {
-        if (model == null) {
+        if (problem == null) {
             return;
         }
 
-        // Here you would update the variable labels based on the model
-        // For example, if model is an LCSProblem:
-        /*
-        if (model instanceof LCSProblem) {
-            LCSProblem lcsProblem = (LCSProblem) model;
-            rValue.setText(String.valueOf(lcsProblem.getR()));
-            cValue.setText(String.valueOf(lcsProblem.getC()));
-            iValue.setText(String.valueOf(lcsProblem.getI()));
-            jValue.setText(String.valueOf(lcsProblem.getJ()));
+        switch(problem.getType()) {
+            case LCS_PROBLEM:
+                int r = problem.getVariableValue("r");
+                int c = problem.getVariableValue("c");
+                int i = problem.getVariableValue("i");
+                int j = problem.getVariableValue("j");
+                int lineNum = problem.getNextLineNumber();
+                String x = ((LCSProblem) problem).getX();
+                String y = ((LCSProblem) problem).getY();
+                
+                /*
+                -1 is a flag value that says "this variables is not in play right now",
+                so we will not display that
+                Also, the table starts with -1, but Java arrays start with 0, so we
+                must adjust
+                */
+                String rText = (r > -1) ? String.valueOf(problem.getVariableValue("r") - 1) : "";
+                String cText = (c > -1) ? String.valueOf(problem.getVariableValue("c") - 1) : "";
+                String iText = (i > -1) ? String.valueOf(problem.getVariableValue("i") - 1) : "";
+                String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
+                String xrText;
+                String ycText;
+                
+                //-----------------------EXCEPTIONS-----------------------------
+                
+                // We want to see the chars when we're on the relevant line
+                if (lineNum == 7) {
+                    xrText = String.valueOf(x.charAt(i - 1));
+                    ycText = String.valueOf(y.charAt(j - 1));
+                } else if (lineNum == 103 || lineNum == 104) {
+                    xrText = String.valueOf(x.charAt(r - 1));
+                    ycText = String.valueOf(y.charAt(c - 1));
+                } else {
+                    xrText = "";
+                    ycText = "";
+                }
+                
+                // We want to see the while loop values before they are set
+                if (lineNum == 101) {
+                    rText = String.valueOf(problem.getVariableValue("n") - 1);
+                    cText = String.valueOf(problem.getVariableValue("m") - 1);
+                }
+
+                /*
+                We want the for loops to display their variable's value before it is set
+                */
+                if (lineNum == 1) rText = String.valueOf(r);
+                if (lineNum == 3) {
+                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                }
+                if (lineNum == 5) {
+                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                }
+                if (lineNum == 6) {
+                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                }
+                
+                rValue.setText(rText);
+                cValue.setText(cText);
+                iValue.setText(iText);
+                jValue.setText(jText);
+                nValue.setText(String.valueOf(x.length()));
+                mValue.setText(String.valueOf(y.length()));
+                xrValue.setText(xrText);
+                ycValue.setText(ycText);
+                lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
         }
-        */
+    }
+
+    @Override
+    public void problemUpdated(Problem model) {
+        updateView();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -24,8 +24,8 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * So much of this code is specific to LCSProblem, it might be worthwhile to
- * write separate variable views for each problem type. -Gary 10/2025
+ * So much of this code is specific to LCSProblem, it might be worthwhile to write separate variable
+ * views for each problem type. -Gary 10/2025
  */
 public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
@@ -386,7 +386,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String xrText;
                 String ycText;
 
-                //-----------------------EXCEPTIONS-----------------------------
+                // -----------------------EXCEPTIONS-----------------------------
 
                 // We want to see the chars, but only when we're on the relevant line
 
@@ -430,7 +430,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 xrValue.setText(xrText);
                 ycValue.setText(ycText);
                 lcsValue.setText(((LCSProblem) problem).getCurrentLcs());
-                
+
                 break;
             default:
                 // Other problem types coming... soon?

--- a/src/main/java/edu/regis/dptu/view/VariablesView.java
+++ b/src/main/java/edu/regis/dptu/view/VariablesView.java
@@ -12,7 +12,6 @@
  */
 package edu.regis.dptu.view;
 
-import edu.regis.dptu.model.LCSProblem;
 import java.awt.GridBagConstraints;
 
 import javax.swing.JLabel;
@@ -20,6 +19,7 @@ import javax.swing.JLabel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
@@ -30,8 +30,24 @@ public class VariablesView extends GPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(VariablesView.class);
 
     private Problem problem;
-    private JLabel nName, nValue, mName, mValue, rName, rValue, cName, cValue, iName, iValue, 
-            jName, jValue, xrName, xrValue, ycName, ycValue, lcsName, lcsValue;
+    private JLabel nName,
+            nValue,
+            mName,
+            mValue,
+            rName,
+            rValue,
+            cName,
+            cValue,
+            iName,
+            iValue,
+            jName,
+            jValue,
+            xrName,
+            xrValue,
+            ycName,
+            ycValue,
+            lcsName,
+            lcsValue;
 
     public VariablesView() {
         initializeComponents();
@@ -40,7 +56,7 @@ public class VariablesView extends GPanel implements ProblemListener {
 
     public void setModel(Problem model) {
         this.problem = model;
-        
+
         if (this.problem != null) {
             this.problem.addProblemListener(this);
         }
@@ -280,7 +296,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 ycName,
                 2,
@@ -310,7 +326,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 5,
                 5,
                 5);
-        
+
         addc(
                 lcsName,
                 2,
@@ -347,7 +363,7 @@ public class VariablesView extends GPanel implements ProblemListener {
             return;
         }
 
-        switch(problem.getType()) {
+        switch (problem.getType()) {
             case LCS_PROBLEM:
                 int r = problem.getVariableValue("r");
                 int c = problem.getVariableValue("c");
@@ -356,7 +372,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                 int lineNum = problem.getNextLineNumber();
                 String x = ((LCSProblem) problem).getX();
                 String y = ((LCSProblem) problem).getY();
-                
+
                 /*
                 -1 is a flag value that says "this variables is not in play right now",
                 so we will not display that
@@ -369,9 +385,9 @@ public class VariablesView extends GPanel implements ProblemListener {
                 String jText = (j > -1) ? String.valueOf(problem.getVariableValue("j") - 1) : "";
                 String xrText;
                 String ycText;
-                
-                //-----------------------EXCEPTIONS-----------------------------
-                
+
+                // -----------------------EXCEPTIONS-----------------------------
+
                 // We want to see the chars when we're on the relevant line
                 if (lineNum == 7) {
                     xrText = String.valueOf(x.charAt(i - 1));
@@ -383,7 +399,7 @@ public class VariablesView extends GPanel implements ProblemListener {
                     xrText = "";
                     ycText = "";
                 }
-                
+
                 // We want to see the while loop values before they are set
                 if (lineNum == 101) {
                     rText = String.valueOf(problem.getVariableValue("n") - 1);
@@ -395,15 +411,15 @@ public class VariablesView extends GPanel implements ProblemListener {
                 */
                 if (lineNum == 1) rText = String.valueOf(r);
                 if (lineNum == 3) {
-                    cText = (c== -1) ? String.valueOf(c + 1) : String.valueOf(c);
+                    cText = (c == -1) ? String.valueOf(c + 1) : String.valueOf(c);
                 }
                 if (lineNum == 5) {
-                    iText = (i== -1) ? String.valueOf(i + 1) : String.valueOf(i);
+                    iText = (i == -1) ? String.valueOf(i + 1) : String.valueOf(i);
                 }
                 if (lineNum == 6) {
-                    jText = (j== -1) ? String.valueOf(j + 1) : String.valueOf(j);
+                    jText = (j == -1) ? String.valueOf(j + 1) : String.valueOf(j);
                 }
-                
+
                 rValue.setText(rText);
                 cValue.setText(cText);
                 iValue.setText(iText);

--- a/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/LCSProblemTest.java
@@ -61,7 +61,7 @@ public class LCSProblemTest {
         assertEquals(y.length(), m);
         assertEquals(LCSProblem.EXECUTION_STATE.PRE, problem.getExecutionState());
 
-        assertEquals(0, problem.getCurrentLineNumber());
+        assertEquals(0, problem.getNextLineNumber());
         problem.step(); // executeLine0 LCS(x,y);
         assertEquals(LCSProblem.EXECUTION_STATE.R_LOOP, problem.getExecutionState());
 
@@ -69,13 +69,13 @@ public class LCSProblemTest {
 
         // Execute the r loop
         while (r <= n) { // we start with r==0 which corresponds to -1 on the table
-            assertEquals(1, problem.getCurrentLineNumber());
+            assertEquals(1, problem.getNextLineNumber());
             problem.step(); // Line 1 r++
             r++;
             problem.step(); // Line 2 L[r,-1] = 0;
         }
 
-        assertEquals(1, problem.getCurrentLineNumber());
+        assertEquals(1, problem.getNextLineNumber());
         problem.step(); // Line 1 one last time to increment r past the boundary and break the loop
 
         assertEquals(LCSProblem.EXECUTION_STATE.C_LOOP, problem.getExecutionState());
@@ -83,47 +83,47 @@ public class LCSProblemTest {
 
         // c loop
         for (int c = 0; c < m; c++) {
-            assertEquals(3, problem.getCurrentLineNumber());
+            assertEquals(3, problem.getNextLineNumber());
             problem.step(); // Line 3 c++
             problem.step(); // Line 4 L[-1,c] = 0;
         }
 
-        assertEquals(3, problem.getCurrentLineNumber());
+        assertEquals(3, problem.getNextLineNumber());
         problem.step(); // Line 3 one last time; sets execution state to I_LOOP and goto Line 5
         assertEquals(-1, problem.getVariableValue("c"));
 
-        for (int i = 0; i < n; i++) {
+        for (int row = 0; row < n; row++) {
             assertEquals(LCSProblem.EXECUTION_STATE.I_LOOP, problem.getExecutionState());
-            assertEquals(5, problem.getCurrentLineNumber());
+            assertEquals(5, problem.getNextLineNumber());
             problem.step(); // Line 5 i loop
             assertEquals(LCSProblem.EXECUTION_STATE.J_LOOP, problem.getExecutionState());
-            for (int j = 0; j < m; j++) {
-                assertEquals(i + 1, problem.getVariableValue("i"));
-                assertEquals(6, problem.getCurrentLineNumber());
+            for (int col = 0; col < m; col++) {
+                assertEquals(row + 1, problem.getVariableValue("r"));
+                assertEquals(6, problem.getNextLineNumber());
                 problem.step(); // Line 6: j loop
-                assertEquals(j + 1, problem.getVariableValue("j"));
-                assertEquals(7, problem.getCurrentLineNumber());
+                assertEquals(col + 1, problem.getVariableValue("c"));
+                assertEquals(7, problem.getNextLineNumber());
                 problem.step(); // Line 7: if statement always executes
-                if (x.charAt(i) == y.charAt(j)) {
-                    assertEquals(8, problem.getCurrentLineNumber());
+                if (x.charAt(row) == y.charAt(col)) {
+                    assertEquals(8, problem.getNextLineNumber());
                     problem.step(); // Line 8
                 } else {
-                    assertEquals(9, problem.getCurrentLineNumber());
+                    assertEquals(9, problem.getNextLineNumber());
                     problem.step(); // Line 9
                     problem.step(); // Line 10
                 }
             }
-            assertEquals(6, problem.getCurrentLineNumber());
+            assertEquals(6, problem.getNextLineNumber());
             problem.step(); // Line 6 one last time to break the j loop
             // assertEquals(LCSProblem.EXECUTION_STATE.I_LOOP, problem.getExecutionState());
         }
 
-        assertEquals(5, problem.getCurrentLineNumber());
+        assertEquals(5, problem.getNextLineNumber());
         problem.step(); // Line 5 one last time to break the i loop and go to line 11
 
         assertEquals(LCSProblem.EXECUTION_STATE.RETRN, problem.getExecutionState());
-        assertEquals(-1, problem.getVariableValue("i"));
-        assertEquals(-1, problem.getVariableValue("j"));
+        assertEquals(-1, problem.getVariableValue("r"));
+        assertEquals(-1, problem.getVariableValue("c"));
 
         problem.step(); // Line 11
 
@@ -251,13 +251,13 @@ public class LCSProblemTest {
 
         problem.undo(); // Line 5 last time checking i loop
         assertEquals(LCSProblem.EXECUTION_STATE.I_LOOP, problem.getExecutionState());
-        for (int i = n - 1; i >= 0; i--) {
+        for (row = n - 1; row >= 0; row--) {
             problem.undo(); // Line 6 last time checking j loop
             assertEquals(LCSProblem.EXECUTION_STATE.J_LOOP, problem.getExecutionState());
-            for (int j = m - 1; j >= 0; j--) {
+            for (col = m - 1; col >= 0; col--) {
                 String word1 = problem.getX();
                 String word2 = problem.getY();
-                if (word1.charAt(i) == word2.charAt(j)) {
+                if (word1.charAt(row) == word2.charAt(col)) {
                     problem.undo(); // Line 8 L[i,j] = L[i-1,j-1] + 1
                     problem.undo(); // Line 7 if xi == yj
                     problem.undo(); // Line 6 for j=0 to m-1

--- a/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
+++ b/src/test/java/edu/regis/dptu/test/MatrixChainProblemTest.java
@@ -51,12 +51,12 @@ public class MatrixChainProblemTest {
         problem.prettyPrint();
 
         // Now test undo all the way back to PRE
-        while (problem.getCurrentLineNumber() != 0) {
+        while (problem.getNextLineNumber() != 0) {
             problem.undo();
         }
 
         // Final state after undoing everything
-        assertTrue(problem.getCurrentLineNumber() == 0);
+        assertTrue(problem.getNextLineNumber() == 0);
 
         problem.prettyPrint();
     }

--- a/src/test/java/edu/regis/dptu/test/TestStepExecution.java
+++ b/src/test/java/edu/regis/dptu/test/TestStepExecution.java
@@ -44,13 +44,13 @@ public class TestStepExecution implements ProblemListener {
         problem.addProblemListener(this);
 
         System.out.println("\n--- Testing step() ---");
-        System.out.println("Initial state: line " + problem.getCurrentLineNumber());
+        System.out.println("Initial state: line " + problem.getNextLineNumber());
 
         // Test stepping forward
         for (int i = 0; i < 5; i++) {
             System.out.println("\nExecuting step " + (i + 1));
             problem.step();
-            System.out.println("Current line: " + problem.getCurrentLineNumber());
+            System.out.println("Current line: " + problem.getNextLineNumber());
         }
 
         System.out.println("\n--- Testing undo() ---");
@@ -58,18 +58,18 @@ public class TestStepExecution implements ProblemListener {
         for (int i = 0; i < 3; i++) {
             System.out.println("\nExecuting undo " + (i + 1));
             problem.undo();
-            System.out.println("Current line: " + problem.getCurrentLineNumber());
+            System.out.println("Current line: " + problem.getNextLineNumber());
         }
 
         System.out.println("\n--- Testing reset() ---");
         // Test resetting
         problem.reset();
-        System.out.println("After reset: line " + problem.getCurrentLineNumber());
+        System.out.println("After reset: line " + problem.getNextLineNumber());
 
         System.out.println("\n--- Testing multiple steps ---");
         // Test multiple steps
         problem.step(3);
-        System.out.println("After 3 steps: line " + problem.getCurrentLineNumber());
+        System.out.println("After 3 steps: line " + problem.getNextLineNumber());
 
         System.out.println("\n=== Test Complete ===");
     }
@@ -78,6 +78,6 @@ public class TestStepExecution implements ProblemListener {
     public void problemUpdated(Problem problem) {
         System.out.println(
                 "LISTENER: Problem updated notification received. Current line: "
-                        + problem.getCurrentLineNumber());
+                        + problem.getNextLineNumber());
     }
 }


### PR DESCRIPTION

Incorporates work from DPTU-93
### StepViewPanel
Made statusLabel monospaced and used string formatting to make sure the layout doesn't shift when the number changes. And made "Line: ##" the same number of chars as "Finished!" for the same reason.
### SubproblemTableView
Removed reference to i and j variables.
### LCSProblem
I removed variables i and j, reusing r and c instead.
I considered making changes here to that the VariablesView would not require exceptions to display the values we want. I couldn't really visualize what this would entail until I started it. As it turns out, 1) it required really tortured logic that would obscure the functioning of the LCSProblem executeLine methods; and 2) that would only remove some of the exceptions from VariablesView - some will be required no matter what. Specifically, we do not want to see "-1" as a value on row and col; and we do not want to see the value of the chars being compared except on line 7 (these values are meaningless at other times - especially during lines 1-4).
### VariablesView
Updated to remove references to variables i and j.
### Problem
In a previous pr, I had accidentally duplicated a getter with a slightly different name. I fixed it here and then had to update CodeView, BacktrackingCodeView, and StepViewPanel to match.