### PR TITLE
DPTU-99: Update pom.xml to fix Maven issue with SLF4J2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,8 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>1.7.36</version>
+            <type>jar</type>
         </dependency>
 
         <!-- Log4j2 Core + API, Our Logging Engine -->


### PR DESCRIPTION
Bug fix for Maven version of SLF4J. This fix is only temporarily needed until I get the JUL bridging running correctly.