### PR TITLE
DPTU-112 Added noops to LCSProblem, removed them from history

### DIFF
--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -617,12 +617,11 @@ public class LCSProblem extends Problem {
         }
     }
 
-    /** 
-     * This is basically a NOOP
-     * If we try to step past the end of the algorithm, this is the method
-     * that will execute. This can only happen if the user clicks the "run steps"
-     * button several times, launching multiple threads which interfere with the
-     * normal method of checking if the algorithm is finished.
+    /**
+     * This is basically a NOOP If we try to step past the end of the algorithm, this is the method
+     * that will execute. This can only happen if the user clicks the "run steps" button several
+     * times, launching multiple threads which interfere with the normal method of checking if the
+     * algorithm is finished.
      */
     public void executeLine12() {
         int lastLineIndex = executionHistory.size() - 1;
@@ -888,7 +887,7 @@ public class LCSProblem extends Problem {
     public void undoLine11() {
         executionState = EXECUTION_STATE.RETRN;
     }
-    
+
     public void undoLine12() {
         // NOOP
     }
@@ -987,6 +986,6 @@ public class LCSProblem extends Problem {
     }
 
     public void undoLine112() {
-    // NOOP    
+        // NOOP
     }
 }

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -617,6 +617,19 @@ public class LCSProblem extends Problem {
         }
     }
 
+    /** 
+     * This is basically a NOOP
+     * If we try to step past the end of the algorithm, this is the method
+     * that will execute. This can only happen if the user clicks the "run steps"
+     * button several times, launching multiple threads which interfere with the
+     * normal method of checking if the algorithm is finished.
+     */
+    public void executeLine12() {
+        int lastLineIndex = executionHistory.size() - 1;
+        // Remove any record of this line executing
+        executionHistory.remove(lastLineIndex);
+    }
+
     // ---------------------------LCS Algorithm Finished-------------------------
 
     // -----------------------Backtracking Algorithm Begins----------------------
@@ -745,6 +758,12 @@ public class LCSProblem extends Problem {
         executionState = EXECUTION_STATE.B_POST;
     }
 
+    /** This is basically a NOOP. We will remove it from executionHistory */
+    public void executeLine112() {
+        int lastLineIndex = executionHistory.size() - 1;
+        executionHistory.remove(lastLineIndex);
+    }
+
     // ---------------------Backtracking Finished--------------------------------
 
     // -----------------------------Undo-----------------------------------------
@@ -869,6 +888,10 @@ public class LCSProblem extends Problem {
     public void undoLine11() {
         executionState = EXECUTION_STATE.RETRN;
     }
+    
+    public void undoLine12() {
+        // NOOP
+    }
 
     // ----------------------------Undo Backtracking-----------------------------
 
@@ -961,5 +984,9 @@ public class LCSProblem extends Problem {
     /** Undoes executeLine111: Return LCS */
     public void undoLine111() {
         executionState = EXECUTION_STATE.B_RETRN;
+    }
+
+    public void undoLine112() {
+    // NOOP    
     }
 }


### PR DESCRIPTION
If you click "run steps" several times, you launch multiple threads which can interfere with the mechanism that stops the algorithm from trying to execute beyond the finish line. I added more executeLine and undoLine methods so no exceptions will be thrown if this happens. I also removed any extra lines from the execution history so that the user can hit the back button exactly once to start undoing the algorithm.