### PR TITLE
DPTU-114 Removed Student from TutoringSession; fixed Dashboard

### DIFF
--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -73,7 +73,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             stmt = conn.prepareStatement(sql, keyCol);
 
             stmt.setString(1, session.getSecurityToken());
-            stmt.setString(2, session.getStudent().getStudentModel().getUserId());
+            stmt.setString(2, session.getUserId());
             stmt.setInt(3, session.getCourse().getId());
             stmt.setInt(4, session.getUnit().getId());
             stmt.setBoolean(5, session.isIsActive());

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -35,8 +35,8 @@ public class TutoringSession {
      */
     private String securityToken = "";
 
-    /** The student being tutored in this session. */
-    private Student student;
+    /** The email address of the student being tutored in this session. */
+    private String userId;
 
     /** A summary of the course currently being taught in this session. */
     private CourseDigest course;
@@ -69,23 +69,22 @@ public class TutoringSession {
     /**
      * Initialize this session with default information.
      *
-     * @param student the Student being tutored in this session.
+     * @param userId - The email address of the student associated with this session.
      */
-    public TutoringSession(Student student) {
-        this.student = student;
+    public TutoringSession(String userId) {
+        this.userId = userId;
         tasks = new ArrayList<>();
     }
 
     /**
-     * Initialize this session with an Account and a Problem. This constructor creates a new Student
-     * object from the Account.
+     * Initialize this session with an Account and a Problem.
      *
      * @param account the Account used to create the Student.
      * @param problem the Problem to be solved in this session.
      * @author EverettCV
      */
     public TutoringSession(Account account, Problem problem) {
-        this.student = new Student(account); // Create a new Student from Account
+        this.userId = account.getUserId();
         this.problem = problem;
         this.tasks = new ArrayList<>(); // Initialize tasks list
     }
@@ -107,16 +106,16 @@ public class TutoringSession {
     }
 
     /**
-     * Return the student being tutored in this tutoring session.
+     * Return the email of the student being tutored in this tutoring session.
      *
-     * @return a Student
+     * @return user's email address
      */
-    public Student getStudent() {
-        return student;
+    public String getUserId() {
+        return userId;
     }
 
-    public void setStudent(Student student) {
-        this.student = student;
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     public CourseDigest getCourse() {

--- a/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
+++ b/src/main/java/edu/regis/dptu/svc/DpTuTutor.java
@@ -169,6 +169,7 @@ public class DpTuTutor implements TutorSvc {
      *
      * @param jsonAcct a JSon encoded Account object
      * @return a TutorReply if successful the status is "Created", otherwise the status is "ERR".
+     * @throws edu.regis.dptu.err.NonRecoverableException
      */
     public TutorReply createAccount(String jsonAcct) throws NonRecoverableException {
         Account acct = gson.fromJson(jsonAcct, Account.class);
@@ -354,7 +355,7 @@ public class DpTuTutor implements TutorSvc {
             throws NonRecoverableException {
         Account account = student.getAccount();
 
-        TutoringSession tSession = new TutoringSession(student);
+        TutoringSession tSession = new TutoringSession(account.getUserId());
         tSession.setStartDate(new GregorianCalendar());
         tSession.setCourse(course.getDigest());
         tSession.setUnit(course.currentUnit().getDigest());

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -25,7 +25,8 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.model.Mode;
 import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.ScaffoldLevel;
-import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.model.Student;
+import edu.regis.dptu.model.aol.StudentModel;
 import edu.regis.dptu.util.CustomProgressBar;
 import edu.regis.dptu.view.act.DoOneAction;
 import edu.regis.dptu.view.act.SeeOneAction;
@@ -34,7 +35,7 @@ import edu.regis.dptu.view.act.TeachOneAction;
 public class DashboardPanel extends GPanel {
     private static final Logger log = LoggerFactory.getLogger(DashboardPanel.class);
 
-    private TutoringSession model;
+    private String firstName;
 
     private JButton logOutButton;
     private JButton settingsButton;
@@ -50,23 +51,20 @@ public class DashboardPanel extends GPanel {
     private static final Color REGIS_BLUE = new Color(0, 43, 73);
     private static final Color REGIS_GOLD = new Color(241, 196, 0);
 
-    public DashboardPanel(TutoringSession tutoringSession) {
-        model = tutoringSession;
+    public DashboardPanel(String firstName) {
+        this.firstName = firstName;
 
-        String welcomeMessage =
-                "Welcome, "
-                        + tutoringSession.getStudent().getAccount().getFirstName()
-                        + "! "
-                        + "Your session has successfully started.";
-        JOptionPane.showMessageDialog(
-                null, welcomeMessage, "Welcome", JOptionPane.INFORMATION_MESSAGE);
+        displayWelcomeDialog();
 
         initializeComponents();
         layoutComponents();
     }
 
-    public void setModel(TutoringSession model) {
-        this.model = model;
+    /* Greets user by name in JOptionPanne and dashboard header. */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+        welcomeLabel.setText("Welcome, " + firstName + "!");
+        displayWelcomeDialog();
     }
 
     /**
@@ -94,8 +92,7 @@ public class DashboardPanel extends GPanel {
         settingsButton = new JButton("Settings");
         settingsButton.setFocusPainted(false);
 
-        welcomeLabel =
-                new JLabel("Welcome, " + model.getStudent().getAccount().getFirstName() + "!");
+        welcomeLabel = new JLabel("Welcome, " + firstName + "!");
         welcomeLabel.setForeground(REGIS_GOLD); // Gold color
         welcomeLabel.setHorizontalAlignment(SwingConstants.CENTER);
         welcomeLabel.setFont(new Font("Segoe UI", Font.PLAIN, 18));
@@ -183,6 +180,16 @@ public class DashboardPanel extends GPanel {
         copyright.setBorder(new EmptyBorder(5, 0, 5, 0));
         add(copyright, BorderLayout.SOUTH);
     }
+    
+    private void displayWelcomeDialog() {
+        String welcomeMessage =
+                "Welcome, "
+                        + firstName
+                        + "! "
+                        + "Your session has successfully started.";
+        JOptionPane.showMessageDialog(
+                null, welcomeMessage, "Welcome", JOptionPane.INFORMATION_MESSAGE);
+    }
 
     private JPanel createColumn(CustomProgressBar progressBar, JButton button, String labelText) {
         JPanel column = new JPanel(new BorderLayout(0, 5));
@@ -221,16 +228,18 @@ public class DashboardPanel extends GPanel {
      * @author hsherwin@regis.edu
      */
     private void applyScaffoldLevelRules() {
+        Student student = SplashFrame.instance().getStudent();
+        StudentModel studentModel;
 
         // Gracefully handle if the model objects don't exist.
-        if (model == null || model.getStudent() == null) {
+        if (student == null) {
             DashboardPanel.log.warn(
-                    "DashboardPanel: model or student is null, " + "skipping scaffold level rules");
+                    "DashboardPanel: student is null, " + "skipping scaffold level rules");
             return;
         }
 
         // Get the current scaffold level.
-        var studentModel = model.getStudent().getStudentModel();
+        studentModel = student.getStudentModel();
         ScaffoldLevel lvl = studentModel.getScaffoldLevel();
         DashboardPanel.log.info("DashboardPanel: applying scaffold level rules for {0}", lvl);
 

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -180,13 +180,10 @@ public class DashboardPanel extends GPanel {
         copyright.setBorder(new EmptyBorder(5, 0, 5, 0));
         add(copyright, BorderLayout.SOUTH);
     }
-    
+
     private void displayWelcomeDialog() {
         String welcomeMessage =
-                "Welcome, "
-                        + firstName
-                        + "! "
-                        + "Your session has successfully started.";
+                "Welcome, " + firstName + "! " + "Your session has successfully started.";
         JOptionPane.showMessageDialog(
                 null, welcomeMessage, "Welcome", JOptionPane.INFORMATION_MESSAGE);
     }

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -25,8 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Account;
-import edu.regis.dptu.model.Mode;
-import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.Student;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.model.User;
 
@@ -93,8 +92,8 @@ public class SplashFrame extends JFrame {
         return reset;
     }
 
-    /** The current tutoring session. */
-    private TutoringSession tutoringSession;
+    /** All student info should reside here. */
+    private Student student;
 
     /** A CardLayout containing all main panels (SPLASH, NEW_USER, DASHBOARD, etc.). */
     private JPanel cards;
@@ -158,6 +157,14 @@ public class SplashFrame extends JFrame {
     public Account getAccount() {
         return newAccountPanel.getModel();
     }
+    
+    public Student getStudent() {
+        return student;
+    }
+    
+    public void setStudent(Student student) {
+        this.student = student;
+    }
 
     /** Display to the user the result of an invalid password in a sign in. */
     public void invalidPass() {
@@ -200,23 +207,17 @@ public class SplashFrame extends JFrame {
     /**
      * Initialize and show dashboard for the given session.
      *
-     * @param session The current tutoring session
+     * @param firstName - The name of this user.
      */
-    public void initializeDashboard(TutoringSession session) {
-        if (session == null) {
-            SplashFrame.log.error("TutoringSession is null in initializeDashboard");
-            return;
-        }
-
-        this.tutoringSession = session;
+    public void initializeDashboard(String firstName) {
 
         // Create new dashboard if it doesn't exist
         if (this.dashboardPanel == null) {
-            this.dashboardPanel = new DashboardPanel(session);
+            this.dashboardPanel = new DashboardPanel(firstName);
             this.cards.add(dashboardPanel, DASHBOARD);
         } else {
             // Update existing dashboard
-            this.dashboardPanel.setModel(session);
+            dashboardPanel.setFirstName(firstName);
         }
 
         // Make sure the dashboard is visible
@@ -294,12 +295,11 @@ public class SplashFrame extends JFrame {
      * Select the lesson screen for the problem. Creates a new TutoringSession
      *
      * @author EverettCV
+     * @param ts - TutoringSession to be displayed for this lesson.
      */
-    public void selectLessonScreen(Problem problem, Mode mode) {
-        this.tutoringSession.setProblem(problem);
-        this.tutoringSession.setMode(mode);
+    public void selectLessonScreen(TutoringSession ts) {
 
-        MainFrame.instance().getView().setModel(tutoringSession);
+        MainFrame.instance().getView().setModel(ts);
 
         // Show the MainFrame (lesson view)
         MainFrame.instance().setVisible(true);

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -157,11 +157,11 @@ public class SplashFrame extends JFrame {
     public Account getAccount() {
         return newAccountPanel.getModel();
     }
-    
+
     public Student getStudent() {
         return student;
     }
-    
+
     public void setStudent(Student student) {
         this.student = student;
     }

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -18,9 +18,11 @@ import java.awt.event.KeyEvent;
 import edu.regis.dptu.dao.ProblemDAO;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Mode;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
+import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.view.DashboardPanel;
 import edu.regis.dptu.view.SplashFrame;
 
@@ -52,7 +54,10 @@ public class DoOneAction extends DpTuGuiAction {
             ProblemKind kind = dashboard.getSelectedProblemKind();
             Problem problem = problemDAO.retrieveByKind(kind);
 
-            SplashFrame.instance().selectLessonScreen(problem, Mode.DO_ONE);
+            Account account = SplashFrame.instance().getAccount();
+            TutoringSession ts = new TutoringSession(account, problem);
+            ts.setMode(Mode.DO_ONE);
+            SplashFrame.instance().selectLessonScreen(ts);
         } catch (ObjNotFoundException | NonRecoverableException e) {
             DoOneAction.log.error(e.getMessage());
             SplashFrame.instance().showError("Error", "Failed to load problem");

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -18,9 +18,11 @@ import java.awt.event.KeyEvent;
 import edu.regis.dptu.dao.ProblemDAO;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Mode;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
+import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.view.DashboardPanel;
 import edu.regis.dptu.view.SplashFrame;
 
@@ -47,6 +49,7 @@ public class SeeOneAction extends DpTuGuiAction {
 
     /**
      * @author EverettCV
+     * @param evt
      */
     @Override
     public void actionPerformed(ActionEvent evt) {
@@ -56,7 +59,10 @@ public class SeeOneAction extends DpTuGuiAction {
 
             Problem problem = problemDAO.retrieveByKind(kind);
 
-            SplashFrame.instance().selectLessonScreen(problem, Mode.SEE_ONE);
+            Account account = SplashFrame.instance().getAccount();
+            TutoringSession ts = new TutoringSession(account, problem);
+            ts.setMode(Mode.SEE_ONE);
+            SplashFrame.instance().selectLessonScreen(ts);
 
         } catch (ObjNotFoundException | NonRecoverableException e) {
             SeeOneAction.log.error(e.getMessage());

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -23,12 +23,13 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 
 import edu.regis.dptu.dao.AccountDAO;
+import edu.regis.dptu.dao.StudentModelDAO;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Student;
-import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.model.User;
+import edu.regis.dptu.model.aol.StudentModel;
 import edu.regis.dptu.svc.ClientRequest;
 import edu.regis.dptu.svc.ServerRequestType;
 import edu.regis.dptu.svc.SvcFacade;
@@ -66,24 +67,28 @@ public class SignInAction extends DpTuGuiAction {
     public void actionPerformed(ActionEvent evt) {
         Gson gson = new Gson();
         SplashFrame frame = SplashFrame.instance();
-        User account = frame.getUser();
+        User user = frame.getUser();
 
         ClientRequest request = new ClientRequest(ServerRequestType.SIGN_IN);
-        request.setData(gson.toJson(account));
+        request.setData(gson.toJson(user));
         TutorReply reply = SvcFacade.instance().tutorRequest(request);
 
         switch (reply.getStatus()) {
             case "Authenticated":
                 try {
                     AccountDAO accDao = new AccountDAO();
-                    Account studentAccount = accDao.retrieve(account.getUserId());
+                    Account studentAccount = accDao.retrieve(user.getUserId());
+                    StudentModelDAO smDao = new StudentModelDAO();
+                    StudentModel sm = smDao.retrieve(user.getUserId());
                     Student student = new Student(studentAccount);
+                    student.setStudentModel(sm);
+                    SplashFrame.instance().setStudent(student);
 
                     if (student.getStudentModel().getSessions().isEmpty()) {
                         frame.setIsFirstLogin(true);
                     }
-                    TutoringSession studentSession = new TutoringSession(student);
-                    SplashFrame.instance().initializeDashboard(studentSession);
+                    String name = studentAccount.getFirstName();
+                    SplashFrame.instance().initializeDashboard(name);
                 } catch (ObjNotFoundException e) {
                     System.out.println("No account found");
                 } catch (NonRecoverableException e) {


### PR DESCRIPTION
### SessionDAO.java
- gets userId from the session

### TutoringSession.java
- changed a member from Student to userId (i.e. email)

### DpTuTutor.java
- uses the new TutoringSession constructor (userId instead of student)

### DashboardPanel.java
- The dashboard used the tutoring session for 2 things: to get the user's first name and to find the scaffold level. firstName is now a parameter in the constructor and scaffold level comes from the student object residing in SplashFrame.
- Fixed issue where the user's name did not display correctly if one user logs out and another logs in.

### SplashFrame.java
- I decided to store the Student object here. Since this is a singleton, the student can be retrieved from anywhere.

### DoOneAction.java
- This is a kludge on top of a kludge. First of all, we shouldn't be accessing the database from here (a remote procedure call is required). But also, I think a Problem is not the right object to be retrieving from the database – instead the database should create a new TutoringSession and then send it to the client. I have not attempted to fix this here as I have not yet been able to figure out how to deserialize a TutoringSession object with GSON.

### SeeOneAction.java
- Same changes as DoOneAction.

### SignInAction.java
- I renamed the User variable, since "account" is a different class.
All we need now to call initializeDashboard() is the student's first name.
Btw, this also has inappropriate database access. I attempted to fix it by having the initial ClientRequest return a Student object in reply.getData(), but I couldn't figure out the GSON.