### PR TITLE
DPTU-129-A: Fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/logging-check.yml
+++ b/.github/workflows/logging-check.yml
@@ -1,5 +1,8 @@
 name: Logging Standards Check
 
+permissions:
+  contents: read
+
 # This workflow enforces the DpTu Logging Developer Guide.
 #
 # Goals:


### PR DESCRIPTION
Fix for [https://github.com/rblument/DpTuApp/security/code-scanning/2](https://github.com/rblument/DpTuApp/security/code-scanning/2)

To fix this, add an explicit `permissions` block limiting the `GITHUB_TOKEN` to the minimal rights needed. This workflow only needs to read repository contents to run `actions/checkout` and then scan files, so `contents: read` is sufficient. No other scopes (issues, pull-requests, actions, etc.) are required.

The best fix without changing functionality is:

- Add a workflow-level `permissions:` block directly under the `name:` or `on:` section so it applies to all jobs (there is only one job in this file).
- Set `contents: read` as the only permission, documenting that the workflow is read-only with respect to repository contents.

Concretely, in `.github/workflows/logging-check.yml`:

- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the `name: Logging Standards Check` header and the `on:` block (or immediately after `on:`—either is valid, but placing it near the top improves visibility).

No imports or additional methods are needed; this is a pure YAML configuration change inside the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---
Manually reviewed by me as well.
