### PR TITLE
DPTU-129-B: Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, development ]
   workflow_dispatch: #allow manual runs
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for [https://github.com/rblument/DpTuApp/security/code-scanning/1](https://github.com/rblument/DpTuApp/security/code-scanning/1)

In general, fix this by adding a `permissions:` block that explicitly scopes the `GITHUB_TOKEN` to the minimal set of rights required by the workflow. For a build-only workflow that checks out code and runs Maven, the minimal practical permissions are `contents: read`, which allows reading the repository contents for checkout and nothing more. This block can be added either at the workflow root (applies to all jobs) or at the job level (applies to that job only).

The best fix here, without changing existing functionality, is to add a root-level `permissions:` block right after the `name:` (or before `jobs:`). This will apply to the `build` job and any future jobs that do not override permissions. Concretely, edit `.github/workflows/pr-build.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and `jobs:` (or just under `name:`; both are valid). No additional methods, imports, or definitions are needed; we only change the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---
Also, manually reviewed by me.
