### PR TITLE
DPTU-140: Rename ShaTu references to DpTu

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In the `documentation` directory, the `DatabaseDiagram.erdplus` file is an Entit
 
 As of 3 May 2025 (end of the Spring 2025 semester), this is the state of the database
 
-![The entity relation diagram of the ShaTu database](documentation/erd.png)
+![The entity relation diagram of the DpTu database](documentation/erd.png)
 
 This project was developed as part of the CS493_X01 Senior Capstone course.
 

--- a/src/main/java/edu/regis/dptu/err/DpTuException.java
+++ b/src/main/java/edu/regis/dptu/err/DpTuException.java
@@ -34,10 +34,10 @@ public abstract class DpTuException extends Exception {
 
     /**
      * Initialize this new instance with the given message and the underlying Java exception that
-     * caused this ShaTu exception.
+     * caused this DpTu exception.
      *
      * @param msg a string describing the cause of this exception.
-     * @param cause the Java exception that caused this ShaTu exception.
+     * @param cause the Java exception that caused this DpTu exception.
      */
     public DpTuException(String msg, Throwable cause) {
         super(msg, cause);

--- a/src/main/java/edu/regis/dptu/err/InconsistentDBException.java
+++ b/src/main/java/edu/regis/dptu/err/InconsistentDBException.java
@@ -37,10 +37,10 @@ public class InconsistentDBException extends NonRecoverableException {
 
     /**
      * Initialize this new instance with the given message and the underlying Java exception that
-     * caused this ShaTu exception and log the exception.
+     * caused this DpTu exception and log the exception.
      *
      * @param msg a string describing the cause of this exception.
-     * @param cause the Java exception that caused this ShaTu exception.
+     * @param cause the Java exception that caused this DpTu exception.
      */
     public InconsistentDBException(String msg, Throwable cause) {
         super(msg, cause);

--- a/src/main/java/edu/regis/dptu/model/Course.java
+++ b/src/main/java/edu/regis/dptu/model/Course.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.err.ObjNotFoundException;
 
 /**
- * A course that may be taught by the ShaTu tutor.
+ * A course that may be taught by the DpTu tutor.
  *
  * @author rickb
  */

--- a/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
+++ b/src/main/java/edu/regis/dptu/model/KnowledgeComponent.java
@@ -23,7 +23,7 @@ import edu.regis.dptu.model.aol.OutcomeGranularity;
  * Per VanLehn (2006), a component of knowledge (concept, rule, procedure, fact) possessed by a
  * student representing a fragment of task-specific information.
  *
- * <p>Knowledge components represent the Outcomes in the ShaTu tutor.
+ * <p>Knowledge components represent the Outcomes in the DpTu tutor.
  *
  * @author rickb
  */

--- a/src/main/java/edu/regis/dptu/model/Student.java
+++ b/src/main/java/edu/regis/dptu/model/Student.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.model.aol.StudentModel;
 
 /**
- * A Student is a user who is being tutored by the ShaTu tutor and consequently has an associated
+ * A Student is a user who is being tutored by the DpTu tutor and consequently has an associated
  * student model.
  *
  * @author rickb

--- a/src/main/java/edu/regis/dptu/model/TaskSelectionKind.java
+++ b/src/main/java/edu/regis/dptu/model/TaskSelectionKind.java
@@ -22,7 +22,7 @@ package edu.regis.dptu.model;
 public enum TaskSelectionKind {
     /**
      * Via a gesture in the user interface, the student selects the next task. This is used in the
-     * ShaTu tutor to allow the student to practice a task at any time.
+     * DpTu tutor to allow the student to practice a task at any time.
      */
     STUDENT_CHOICE("Student Choice"),
 

--- a/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
+++ b/src/main/java/edu/regis/dptu/svc/ServiceFactory.java
@@ -25,7 +25,7 @@ import edu.regis.dptu.dao.StudentModelDAO;
 
 /**
  * A singleton providing a concrete implementation of the service factory used to obtain references
- * to various ShaTu tutoring services.
+ * to various DpTu tutoring services.
  *
  * <p>Use of the service factory allows easier changes to how the services are actually implemented
  * without directly affecting the consumers who use them.
@@ -80,7 +80,7 @@ public class ServiceFactory {
      *
      * @return StudentSvc
      */
-    // ToDo: add this support ala ShaTu
+    // ToDo: add this support ala DpTu
     public static StudentModelSvc findStudentModelSvc() {
         log.debug("ServiceFactory: Retrieving StudentModelSvc instance");
         return new StudentModelDAO();

--- a/src/main/java/edu/regis/dptu/svc/TutorSvc.java
+++ b/src/main/java/edu/regis/dptu/svc/TutorSvc.java
@@ -13,7 +13,7 @@
 package edu.regis.dptu.svc;
 
 /**
- * Specifies the behaviors provided by the ShaTu tutor.
+ * Specifies the behaviors provided by the DpTu tutor.
  *
  * <p>The actual behaviors are specified by request type within the client request. These requests
  * are documented with

--- a/src/main/java/edu/regis/dptu/view/act/ActionFactory.java
+++ b/src/main/java/edu/regis/dptu/view/act/ActionFactory.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Factory for creating the GUI actions used in the ShaTu user interface.
+ * Factory for creating the GUI actions used in the DpTu user interface.
  *
  * @author rickb
  */

--- a/src/main/resources/DpTu.properties
+++ b/src/main/resources/DpTu.properties
@@ -1,4 +1,4 @@
-# SHATU: SHA-256 Tutor
+# DPTU: Dynamic Programming Tutor
 # 
 #  (C) Johanna & Richard Blumenthal, All rights reserved
 # 

--- a/src/main/resources/Msgs.properties
+++ b/src/main/resources/Msgs.properties
@@ -1,4 +1,4 @@
-# SHATU: SHA-256 Tutor
+# DPTU: Dynamic Programming Tutor
 # 
 #  (C) Johanna & Richard Blumenthal, All rights reserved
 # 


### PR DESCRIPTION
Rebrand project identifiers from 'ShaTu' to 'DpTu' across docs and source comments. Updated README image alt text, Javadoc and inline comments in multiple classes (Course, KnowledgeComponent, Student, TaskSelectionKind, ServiceFactory, TutorSvc, ActionFactory), exception docstrings (DpTuException, InconsistentDBException), and resource headers (DpTu.properties, Msgs.properties). Non-functional branding/documentation changes only.