### PR TITLE
DPTU-141: Update Testing Workflow to Output a Coverage % to README

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,6 +1,8 @@
 name: PR Build Validation
 
 on:
+  push:
+    branches: [ main, development ]
   pull_request:
     branches: [ main, development ]
   workflow_dispatch: #allow manual runs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: #allow manual runs
 
 permissions:
-  contents: read
+  contents: write
   checks: write
 
 jobs:
@@ -25,15 +25,23 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
-    - name: Cache Maven dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+    - name: Run tests and generate coverage report
+      run: mvn -B verify
 
-    - name: Run tests
-      run: mvn -B test
+    - name: Generate JaCoCo coverage badge
+      uses: cicirello/jacoco-badge-generator@v2
+      with:
+        jacoco-csv-file: target/site/jacoco/jacoco.csv
+        badges-directory: .github/badges
+
+    - name: Commit coverage badge (if changed)
+      if: github.ref == 'refs/heads/main'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add .github/badges/*.svg .github/badges/*.json || true
+        git diff --cached --quiet || git commit -m "chore(ci): update coverage badge"
+        git push
 
     - name: Publish test report
       uses: dorny/test-reporter@v1

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 <!-- Status Badges -->
 
-[![Build](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml/badge.svg?branch=main)](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml)
-[![Tests](https://github.com/rblument/DpTuApp/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/rblument/DpTuApp/actions/workflows/test.yml)
-[![Coverage](https://raw.githubusercontent.com/rblument/DpTuApp/main/.github/badges/jacoco.svg)](./.github/badges/jacoco.svg)
+[![Build](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml/badge.svg?branch=development)](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml)
+[![Tests](https://github.com/rblument/DpTuApp/actions/workflows/test.yml/badge.svg?branch=development)](https://github.com/rblument/DpTuApp/actions/workflows/test.yml)
+[![Coverage](https://raw.githubusercontent.com/rblument/DpTuApp/development/.github/badges/jacoco.svg)](./.github/badges/jacoco.svg)
 
 DpTu (Dynamic Programming Tutor) is an Intelligent Tutoring System (ITS) designed to help students learn and practice Dynamic Programming (DP) concepts and algorithms. It provides a step-by-step visual environment for specific DP problems, tracks student progress, and aims to adapt to individual learning needs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 
 # DpTu - Dynamic Programming Tutor
 
+<!-- Status Badges -->
+
+[![Build](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml/badge.svg?branch=main)](https://github.com/rblument/DpTuApp/actions/workflows/pr-build.yml)
+[![Tests](https://github.com/rblument/DpTuApp/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/rblument/DpTuApp/actions/workflows/test.yml)
+[![Coverage](https://raw.githubusercontent.com/rblument/DpTuApp/main/.github/badges/jacoco.svg)](./.github/badges/jacoco.svg)
+
 DpTu (Dynamic Programming Tutor) is an Intelligent Tutoring System (ITS) designed to help students learn and practice Dynamic Programming (DP) concepts and algorithms. It provides a step-by-step visual environment for specific DP problems, tracks student progress, and aims to adapt to individual learning needs.
 
 ## Features

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,14 @@
     <artifactId>DpTuApp</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <exec.mainClass>edu.regis.dptu.DpTuApp</exec.mainClass>
     </properties>
+
     <repositories>
         <repository>
           <id>CronApp</id>
@@ -18,6 +20,7 @@
           <url>	https://artifactory.cronapp.io/public-release/</url>
         </repository>
     </repositories>
+
     <build>
         <resources>
             <resource>
@@ -32,6 +35,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
             </plugin>
+
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
@@ -65,9 +69,30 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                    <id>prepare-agent</id>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                    </execution>
+                    <execution>
+                    <id>report</id>
+                    <phase>verify</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-    
     </build>
+
     <dependencies>
         <!-- Source: https://mvnrepository.com/artifact/com.google.code.gson/gson-extras -->
         <dependency>


### PR DESCRIPTION
- Update build workflow to happen on push so we can generate a badge image.
- Add JaCoCo to test.yml so we can generate a coverage badge.
- Add JaCoCo to pom.xml.
- Add badges to README.md.

This is part of a broader effort to improve our testing in the app, but I'm operating a little blind right now on HOW bad it is.