### PR TITLE
Fixed highlighting in the SubSequence for the LCS Problem via backtracking (removed manual highlight control)

### DIFF
--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -68,6 +68,32 @@ public class LCSProblem extends Problem {
     /** This keeps track of the lcs as determined by the backtracking algorithm */
     private String currentLcs = "";
 
+    private int lastMatchX = -1; //index into x string
+    private int lastMatchY = -1; //index into y string
+
+    public int getLastMatchX() { return lastMatchX ;}
+    public int getLastMatchY() { return lastMatchY; }
+
+    /**
+     * Record the most recent (x, y) char match chosen by the LCS BACKTRACKING ALG
+     * 
+     * <p> This is intentionally used during backtracking (diagonal "add to solution")
+     * steps, in executeLine104(), not during the forward DP table fill. DP fill may
+     * encounter many incidental matches that are not part of the final LCS
+     * 
+     * <p> After recording the indices this method notifies ProblemListeners so
+     * views (SubSequenceView) can highlight the corresponding characters
+     * 
+     * @param xIdx zero-based index into x (original input string)
+     * @param yIdx zero-based index into y (original input string)
+     */
+    private void recordMatch(int xIdx, int yIdx) {
+        lastMatchX = xIdx;
+        lastMatchY = yIdx;
+        notifyProblemListeners();
+        log.debug("LCSProblem: recordMatch({}, {})", xIdx, yIdx);
+    }
+
     /**
      * The current state of the algorithm, before the loops, in a loop, and after all of the loops
      * have executed.
@@ -691,6 +717,8 @@ public class LCSProblem extends Problem {
         int row = (int) variables.get("r");
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
+        recordMatch(row - 1, col - 1);
+        log.debug("LCS BACKTRACK executeLine104 HIT: row={}, col={}, char={}", row, col, y.charAt(col - 1));
         bTable[row][col] = ADD_TO_SOLUTION; // highlight in green
         currentLcs = y.charAt(col - 1) + currentLcs;
         nextLineNumber = 105;

--- a/src/main/java/edu/regis/dptu/model/LCSProblem.java
+++ b/src/main/java/edu/regis/dptu/model/LCSProblem.java
@@ -68,22 +68,27 @@ public class LCSProblem extends Problem {
     /** This keeps track of the lcs as determined by the backtracking algorithm */
     private String currentLcs = "";
 
-    private int lastMatchX = -1; //index into x string
-    private int lastMatchY = -1; //index into y string
+    private int lastMatchX = -1; // index into x string
+    private int lastMatchY = -1; // index into y string
 
-    public int getLastMatchX() { return lastMatchX ;}
-    public int getLastMatchY() { return lastMatchY; }
+    public int getLastMatchX() {
+        return lastMatchX;
+    }
+
+    public int getLastMatchY() {
+        return lastMatchY;
+    }
 
     /**
      * Record the most recent (x, y) char match chosen by the LCS BACKTRACKING ALG
-     * 
-     * <p> This is intentionally used during backtracking (diagonal "add to solution")
-     * steps, in executeLine104(), not during the forward DP table fill. DP fill may
-     * encounter many incidental matches that are not part of the final LCS
-     * 
-     * <p> After recording the indices this method notifies ProblemListeners so
-     * views (SubSequenceView) can highlight the corresponding characters
-     * 
+     *
+     * <p>This is intentionally used during backtracking (diagonal "add to solution") steps, in
+     * executeLine104(), not during the forward DP table fill. DP fill may encounter many incidental
+     * matches that are not part of the final LCS
+     *
+     * <p>After recording the indices this method notifies ProblemListeners so views
+     * (SubSequenceView) can highlight the corresponding characters
+     *
      * @param xIdx zero-based index into x (original input string)
      * @param yIdx zero-based index into y (original input string)
      */
@@ -718,7 +723,11 @@ public class LCSProblem extends Problem {
         int col = (int) variables.get("c");
         int[][] bTable = (int[][]) variables.get(backtrackingTableVariable);
         recordMatch(row - 1, col - 1);
-        log.debug("LCS BACKTRACK executeLine104 HIT: row={}, col={}, char={}", row, col, y.charAt(col - 1));
+        log.debug(
+                "LCS BACKTRACK executeLine104 HIT: row={}, col={}, char={}",
+                row,
+                col,
+                y.charAt(col - 1));
         bTable[row][col] = ADD_TO_SOLUTION; // highlight in green
         currentLcs = y.charAt(col - 1) + currentLcs;
         nextLineNumber = 105;

--- a/src/main/java/edu/regis/dptu/view/StepViewPanel.java
+++ b/src/main/java/edu/regis/dptu/view/StepViewPanel.java
@@ -153,7 +153,7 @@ public class StepViewPanel extends GPanel implements ProblemListener {
                         }
                     }
                 });
-        stepBackButton.setEnabled(false);
+        stepBackButton.setEnabled(true);
 
         stepForwardButton = new JButton("Step Forward");
         stepForwardButton.setToolTipText("Advance one step in the algorithm");

--- a/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
@@ -33,8 +33,10 @@ public class SubSequenceCanvasView extends JPanel {
 
     private String word1;
     private String word2;
-    private String lcs;
-    private int highlightIndex = 0;
+    private boolean loggedMissingHighlightState = false;
+    private boolean[] w1Highlighted; //word 1 highlighted letters
+    private boolean[] w2Highlighted; //word 2 highlighted letters
+    private static final Font WORD_FONT = new Font("Arial", Font.PLAIN, 20);
 
     /**
      * @param word1
@@ -44,16 +46,16 @@ public class SubSequenceCanvasView extends JPanel {
         this.word1 = word1;
         this.word2 = word2;
 
-        lcs = findLCS(this.word1, this.word2);
+        initHighlightState();
 
         setLayout(null);
         setPreferredSize(new Dimension(600, 300));
 
         log.debug(
-                "SubSequenceCanvasView initialized: word1Len={}, word2Len={}, lcsLen={}",
+                "SubSequenceCanvasView initialized: word1Len={}, word2Len={}, highlightStateReady={}",
                 this.word1 != null ? this.word1.length() : -1,
                 this.word2 != null ? this.word2.length() : -1,
-                this.lcs != null ? this.lcs.length() : -1);
+                (w1Highlighted != null && w2Highlighted != null));
     }
 
     /**
@@ -75,169 +77,195 @@ public class SubSequenceCanvasView extends JPanel {
     }
 
     /**
-     * This is the logic to find the longest common sequence (LCS).
-     *
-     * @param main
-     * @param sub
-     */
-    private String findLCS(String main, String sub) {
-        if (main == null || sub == null) {
-            log.warn(
-                    "findLCS called with null input: mainNull={}, subNull={}",
-                    main == null,
-                    sub == null);
-            return "";
-        }
-
-        int[][] dp = new int[main.length() + 1][sub.length() + 1];
-
-        for (int i = 1; i <= main.length(); i++) {
-            for (int j = 1; j <= sub.length(); j++) {
-                if (main.charAt(i - 1) == sub.charAt(j - 1)) {
-                    dp[i][j] = dp[i - 1][j - 1] + 1;
-                } else {
-                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-                }
-            }
-        }
-
-        // Backtracking
-        StringBuilder lcsBuild = new StringBuilder();
-        int i = main.length(), j = sub.length();
-        while (i > 0 && j > 0) {
-            if (main.charAt(i - 1) == sub.charAt(j - 1)) {
-                lcsBuild.append(main.charAt(i - 1));
-                i--;
-                j--;
-            } else if (dp[i - 1][j] >= dp[i][j - 1]) {
-                i--;
-            } else {
-                j--;
-            }
-        }
-
-        return lcsBuild.reverse().toString();
-    }
-
-    /** When the button is pressed, it highlights the sequence of the two words. */
-    public void highlightLCS() {
-        if (lcs == null) {
-            log.warn("highlightLCS called but lcs is null");
-            return;
-        }
-
-        if (highlightIndex < lcs.length()) {
-            highlightIndex++;
-            log.debug("Highlight advanced: highlightIndex={}/{}", highlightIndex, lcs.length());
-            repaint();
-        } else {
-            log.debug(
-                    "Highlight already complete: highlightIndex={}/{}",
-                    highlightIndex,
-                    lcs.length());
-        }
-    }
-
-    /**
-     * This displays the two words onto the canvas view, and when the button is clicked, then it
-     * will find the common letters shared.
-     *
-     * @param g
+     * Paint the two input words, then overlay any chars that have been marked
+     * as part of the LCS solution path
+     * 
+     * <p>Highlight state is maintained as per-char boolean arrays that persist
+     * across repaints. The model/view controller calls highlightAt(xIdx, yIdx) as 
+     * backtracking commits each character into the solution
+     * 
+     * @param Graphics g
      */
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
-        g.setFont(new Font("Arial", Font.PLAIN, 20));
+        g.setFont(WORD_FONT);
 
         if (word1 == null || word2 == null) {
             g.setColor(Color.RED);
             g.drawString("Invalid input!", 20, 30);
-            return; // prevent NPEs below
-        }
-
-        // draw the words in black
-        int x1 = 20;
-        int y1 = 30;
-        g.setColor(Color.BLACK);
-        g.drawString(word1, x1, y1);
-
-        int x2 = 20;
-        int y2 = 60;
-        g.drawString(word2, x2, y2);
-
-        // draw over the black with green
-        g.setColor(new Color(0, 220, 0));
-        int count = 0;
-
-        int idx1 = word1.length() - 1;
-        int idx2 = word2.length() - 1;
-
-        if (lcs == null) {
             return;
         }
 
-        for (int i = lcs.length() - 1; i >= 0; i--) {
-            idx1 = word1.lastIndexOf(lcs.charAt(i), idx1);
-            idx2 = word2.lastIndexOf(lcs.charAt(i), idx2);
-            if (count < highlightIndex && idx1 != -1 && idx2 != -1) {
-                g.drawString(
-                        String.valueOf(lcs.charAt(i)),
-                        x1 + g.getFontMetrics().stringWidth(word1.substring(0, idx1)),
-                        y1);
-                g.drawString(
-                        String.valueOf(lcs.charAt(i)),
-                        x2 + g.getFontMetrics().stringWidth(word2.substring(0, idx2)),
-                        y2);
-                count++;
+        final int x = 20;
+        final int y1 = 30;
+        final int y2 = 60;
+
+        //draw the words in black
+        g.setColor(Color.BLACK);
+        g.drawString(word1, x, y1);
+        g.drawString(word2, x, y2);
+
+        //if highlight state isn't initialized yet, nothing to overlay, just render base text
+        if (w1Highlighted == null || w2Highlighted == null) {
+            if (!loggedMissingHighlightState) {
+                log.debug(
+                    "paintComponent called before highlight state initialized: word1Highlighted={}, word2Highlighted={}",
+                    w1Highlighted == null,
+                    w2Highlighted == null);
+                loggedMissingHighlightState = true;
             }
-            idx1--;
-            idx2--;
+            return;
+        }
+        loggedMissingHighlightState = false; //reset once state exists
+
+        //overlay highlighted characters in green at their exact positions
+        g.setColor(new Color(0, 220, 0));
+        var fm = g.getFontMetrics();
+
+        //word1 highlights
+        int maxI = Math.min(word1.length(), w1Highlighted.length);
+        for (int i = 0; i < maxI; i++) {
+            if (!w1Highlighted[i]) continue;
+            int px = x + fm.stringWidth(word1.substring(0, i));
+            g.drawString(String.valueOf(word1.charAt(i)), px, y1);
+        }
+
+        //word2 highlights
+        int maxJ = Math.min(word2.length(), w2Highlighted.length);
+        for (int j = 0; j < maxJ; j++) {
+            if (!w2Highlighted[j]) continue;
+            int px = x + fm.stringWidth(word2.substring(0, j));
+            g.drawString(String.valueOf(word2.charAt(j)), px, y2);
         }
     }
 
     /**
-     * Updates the first string (main sequence) displayed on the canvas.
-     *
-     * <p>Changes (April 17, 2025): - Dynamically updates mainSeq. - Recomputes LCS based on the
-     * updated string. - Resets highlight progress for fresh stepping through LCS.
-     *
-     * @author EverettCV
-     * @param word1 The new main sequence string
+     * Initializes (or resets) the per-character highlight state for both input words
+     * 
+     * <p>This method should be called whenever the input strings change or when
+     * the alg is reset. Each char in word1 and word2 gets a corresponding 
+     * boolean flag indicating whether it has been "naturally" matched by the LCS
+     * alg during execution
      */
-    public void setWord1(String word1) {
-        this.word1 = word1;
-        lcs = findLCS(this.word1, word2);
-        highlightIndex = 0;
+    private void initHighlightState() {
+        if (word1 == null || word2 == null) {
+            log.warn(
+                "initHighlightState called with null input(s): word1Null={}, word2Null={}",
+                word1 == null,
+                word2 == null);
+        }
+
+        w1Highlighted = (word1 == null) ? null : new boolean[word1.length()];
+        w2Highlighted = (word2 == null) ? null : new boolean[word2.length()];
 
         log.debug(
-                "word1 updated: word1Len={}, word2Len={}, lcsLen={}, highlightIndex reset",
-                this.word1 != null ? this.word1.length() : -1,
-                this.word2 != null ? this.word2.length() : -1,
-                this.lcs != null ? this.lcs.length() : -1);
+            "Highlight state initialized: word1Len={}, word2Len={}",
+            word1 != null ? word1.length() : -1,
+            word2 != null ? word2.length() : -1);
+    }
+
+    /**
+     * Highlights the characters at the specified indices in each input word
+     * 
+     * <p>This method is intended to be called by the LCS alg controller when a
+     * matching character pair is encountered during step-by-step execution
+     * Highlighted chars persist until view is reset
+     * 
+     * @param xIdx zero-based index into word1 (x string)
+     * @param yIdx zero-based index into word2 (y string)
+     */
+    public void highlightAt(int xIdx, int yIdx) {
+
+
+        if (w1Highlighted == null || w2Highlighted == null) {
+            log.warn(
+                "highlightAt called before highlight state initialized: xIdx={}, yIdx={}",
+                xIdx, 
+                yIdx);
+            return;
+        }
+
+        if (xIdx < 0 || xIdx >= w1Highlighted.length) {
+            log.error(
+                "highlightAt received out of bounds xIdx: {} (word1Len={})",
+                xIdx,
+                w1Highlighted.length);
+            return;
+        }
+        if (yIdx < 0 || yIdx >= w2Highlighted.length) {
+            log.error(
+                "highlightAt received out of bounds yIdx: {} (word2Len={})",
+                yIdx,
+                w2Highlighted.length);
+            return;
+        }
+
+        //apply persistent highlight
+        w1Highlighted[xIdx] = true;
+        w2Highlighted[yIdx] = true;
+
+        log.debug(
+            "Highlight applied: word1[{}]='{}', word2[{}]='{}'",
+            xIdx,
+            word1 != null && xIdx < word1.length() ? word1.charAt(xIdx) : '?',
+            yIdx,
+            word2 != null && yIdx < word2.length() ? word2.charAt(yIdx) : '?');
 
         repaint();
     }
 
+
     /**
-     * Updates the second string (sub sequence) displayed on the canvas.
+     * Updates the first input string (x) displayed on canvas
      *
-     * <p>Changes (April 17, 2025): - Dynamically updates subSeq. - Recomputes LCS based on the
-     * updated string. - Resets highlight progress for fresh stepping through LCS.
+     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since
+     * previously highlighted indices may no longe rbe valid for new input. LCS is 
+     * not computed here; highlighting driven externally by the algorithm controller
+     * 
+     * @author Lindsey Cox
+     * @param word1 the new first input string (x)
+     */
+    public void setWord1(String word1) {
+        this.word1 = word1;
+        initHighlightState(); //reset highlight arrays for the new word(s)
+
+        log.debug(
+                "word1 updated: word1Len={}, word2Len={}, highlightsReset={}",
+                this.word1 != null ? this.word1.length() : -1,
+                this.word2 != null ? this.word2.length() : -1,
+                true);
+        repaint();
+    }
+
+    /**
+     * Updates the second input string (y) displayed on canvas
      *
-     * @author EverettCV
-     * @param word2 The new sub sequence string
+     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since
+     * previously highlighted indices may no longe rbe valid for new input. LCS is 
+     * not computed here; highlighting driven externally by the algorithm controller
+     * 
+     * @author Lindsey Cox
+     * @param word2 The new second input string (y)
      */
     public void setWord2(String word2) {
         this.word2 = word2;
-        lcs = findLCS(word1, this.word2);
-        highlightIndex = 0;
+        initHighlightState(); //reset highlight arrays for the new word(s)
 
         log.debug(
-                "word2 updated: word1Len={}, word2Len={}, lcsLen={}, highlightIndex reset",
+                "word2 updated: word1Len={}, word2Len={}, highlightsReset={}",
                 this.word1 != null ? this.word1.length() : -1,
                 this.word2 != null ? this.word2.length() : -1,
-                this.lcs != null ? this.lcs.length() : -1);
+                true);
+        repaint();
+    }
 
+    /**
+     * 
+     */
+    public void resetHighlights() 
+    {
+        initHighlightState();
         repaint();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceCanvasView.java
@@ -34,8 +34,8 @@ public class SubSequenceCanvasView extends JPanel {
     private String word1;
     private String word2;
     private boolean loggedMissingHighlightState = false;
-    private boolean[] w1Highlighted; //word 1 highlighted letters
-    private boolean[] w2Highlighted; //word 2 highlighted letters
+    private boolean[] w1Highlighted; // word 1 highlighted letters
+    private boolean[] w2Highlighted; // word 2 highlighted letters
     private static final Font WORD_FONT = new Font("Arial", Font.PLAIN, 20);
 
     /**
@@ -77,13 +77,13 @@ public class SubSequenceCanvasView extends JPanel {
     }
 
     /**
-     * Paint the two input words, then overlay any chars that have been marked
-     * as part of the LCS solution path
-     * 
-     * <p>Highlight state is maintained as per-char boolean arrays that persist
-     * across repaints. The model/view controller calls highlightAt(xIdx, yIdx) as 
-     * backtracking commits each character into the solution
-     * 
+     * Paint the two input words, then overlay any chars that have been marked as part of the LCS
+     * solution path
+     *
+     * <p>Highlight state is maintained as per-char boolean arrays that persist across repaints. The
+     * model/view controller calls highlightAt(xIdx, yIdx) as backtracking commits each character
+     * into the solution
+     *
      * @param Graphics g
      */
     @Override
@@ -101,29 +101,29 @@ public class SubSequenceCanvasView extends JPanel {
         final int y1 = 30;
         final int y2 = 60;
 
-        //draw the words in black
+        // draw the words in black
         g.setColor(Color.BLACK);
         g.drawString(word1, x, y1);
         g.drawString(word2, x, y2);
 
-        //if highlight state isn't initialized yet, nothing to overlay, just render base text
+        // if highlight state isn't initialized yet, nothing to overlay, just render base text
         if (w1Highlighted == null || w2Highlighted == null) {
             if (!loggedMissingHighlightState) {
                 log.debug(
-                    "paintComponent called before highlight state initialized: word1Highlighted={}, word2Highlighted={}",
-                    w1Highlighted == null,
-                    w2Highlighted == null);
+                        "paintComponent called before highlight state initialized: word1Highlighted={}, word2Highlighted={}",
+                        w1Highlighted == null,
+                        w2Highlighted == null);
                 loggedMissingHighlightState = true;
             }
             return;
         }
-        loggedMissingHighlightState = false; //reset once state exists
+        loggedMissingHighlightState = false; // reset once state exists
 
-        //overlay highlighted characters in green at their exact positions
+        // overlay highlighted characters in green at their exact positions
         g.setColor(new Color(0, 220, 0));
         var fm = g.getFontMetrics();
 
-        //word1 highlights
+        // word1 highlights
         int maxI = Math.min(word1.length(), w1Highlighted.length);
         for (int i = 0; i < maxI; i++) {
             if (!w1Highlighted[i]) continue;
@@ -131,7 +131,7 @@ public class SubSequenceCanvasView extends JPanel {
             g.drawString(String.valueOf(word1.charAt(i)), px, y1);
         }
 
-        //word2 highlights
+        // word2 highlights
         int maxJ = Math.min(word2.length(), w2Highlighted.length);
         for (int j = 0; j < maxJ; j++) {
             if (!w2Highlighted[j]) continue;
@@ -142,93 +142,90 @@ public class SubSequenceCanvasView extends JPanel {
 
     /**
      * Initializes (or resets) the per-character highlight state for both input words
-     * 
-     * <p>This method should be called whenever the input strings change or when
-     * the alg is reset. Each char in word1 and word2 gets a corresponding 
-     * boolean flag indicating whether it has been "naturally" matched by the LCS
-     * alg during execution
+     *
+     * <p>This method should be called whenever the input strings change or when the alg is reset.
+     * Each char in word1 and word2 gets a corresponding boolean flag indicating whether it has been
+     * "naturally" matched by the LCS alg during execution
      */
     private void initHighlightState() {
         if (word1 == null || word2 == null) {
             log.warn(
-                "initHighlightState called with null input(s): word1Null={}, word2Null={}",
-                word1 == null,
-                word2 == null);
+                    "initHighlightState called with null input(s): word1Null={}, word2Null={}",
+                    word1 == null,
+                    word2 == null);
         }
 
         w1Highlighted = (word1 == null) ? null : new boolean[word1.length()];
         w2Highlighted = (word2 == null) ? null : new boolean[word2.length()];
 
         log.debug(
-            "Highlight state initialized: word1Len={}, word2Len={}",
-            word1 != null ? word1.length() : -1,
-            word2 != null ? word2.length() : -1);
+                "Highlight state initialized: word1Len={}, word2Len={}",
+                word1 != null ? word1.length() : -1,
+                word2 != null ? word2.length() : -1);
     }
 
     /**
      * Highlights the characters at the specified indices in each input word
-     * 
-     * <p>This method is intended to be called by the LCS alg controller when a
-     * matching character pair is encountered during step-by-step execution
-     * Highlighted chars persist until view is reset
-     * 
+     *
+     * <p>This method is intended to be called by the LCS alg controller when a matching character
+     * pair is encountered during step-by-step execution Highlighted chars persist until view is
+     * reset
+     *
      * @param xIdx zero-based index into word1 (x string)
      * @param yIdx zero-based index into word2 (y string)
      */
     public void highlightAt(int xIdx, int yIdx) {
 
-
         if (w1Highlighted == null || w2Highlighted == null) {
             log.warn(
-                "highlightAt called before highlight state initialized: xIdx={}, yIdx={}",
-                xIdx, 
-                yIdx);
+                    "highlightAt called before highlight state initialized: xIdx={}, yIdx={}",
+                    xIdx,
+                    yIdx);
             return;
         }
 
         if (xIdx < 0 || xIdx >= w1Highlighted.length) {
             log.error(
-                "highlightAt received out of bounds xIdx: {} (word1Len={})",
-                xIdx,
-                w1Highlighted.length);
+                    "highlightAt received out of bounds xIdx: {} (word1Len={})",
+                    xIdx,
+                    w1Highlighted.length);
             return;
         }
         if (yIdx < 0 || yIdx >= w2Highlighted.length) {
             log.error(
-                "highlightAt received out of bounds yIdx: {} (word2Len={})",
-                yIdx,
-                w2Highlighted.length);
+                    "highlightAt received out of bounds yIdx: {} (word2Len={})",
+                    yIdx,
+                    w2Highlighted.length);
             return;
         }
 
-        //apply persistent highlight
+        // apply persistent highlight
         w1Highlighted[xIdx] = true;
         w2Highlighted[yIdx] = true;
 
         log.debug(
-            "Highlight applied: word1[{}]='{}', word2[{}]='{}'",
-            xIdx,
-            word1 != null && xIdx < word1.length() ? word1.charAt(xIdx) : '?',
-            yIdx,
-            word2 != null && yIdx < word2.length() ? word2.charAt(yIdx) : '?');
+                "Highlight applied: word1[{}]='{}', word2[{}]='{}'",
+                xIdx,
+                word1 != null && xIdx < word1.length() ? word1.charAt(xIdx) : '?',
+                yIdx,
+                word2 != null && yIdx < word2.length() ? word2.charAt(yIdx) : '?');
 
         repaint();
     }
 
-
     /**
      * Updates the first input string (x) displayed on canvas
      *
-     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since
-     * previously highlighted indices may no longe rbe valid for new input. LCS is 
-     * not computed here; highlighting driven externally by the algorithm controller
-     * 
+     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since previously
+     * highlighted indices may no longe rbe valid for new input. LCS is not computed here;
+     * highlighting driven externally by the algorithm controller
+     *
      * @author Lindsey Cox
      * @param word1 the new first input string (x)
      */
     public void setWord1(String word1) {
         this.word1 = word1;
-        initHighlightState(); //reset highlight arrays for the new word(s)
+        initHighlightState(); // reset highlight arrays for the new word(s)
 
         log.debug(
                 "word1 updated: word1Len={}, word2Len={}, highlightsReset={}",
@@ -241,16 +238,16 @@ public class SubSequenceCanvasView extends JPanel {
     /**
      * Updates the second input string (y) displayed on canvas
      *
-     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since
-     * previously highlighted indices may no longe rbe valid for new input. LCS is 
-     * not computed here; highlighting driven externally by the algorithm controller
-     * 
+     * <p>Changes (Feb 15, 2026): - resets any existing character highlights, since previously
+     * highlighted indices may no longe rbe valid for new input. LCS is not computed here;
+     * highlighting driven externally by the algorithm controller
+     *
      * @author Lindsey Cox
      * @param word2 The new second input string (y)
      */
     public void setWord2(String word2) {
         this.word2 = word2;
-        initHighlightState(); //reset highlight arrays for the new word(s)
+        initHighlightState(); // reset highlight arrays for the new word(s)
 
         log.debug(
                 "word2 updated: word1Len={}, word2Len={}, highlightsReset={}",
@@ -260,11 +257,8 @@ public class SubSequenceCanvasView extends JPanel {
         repaint();
     }
 
-    /**
-     * 
-     */
-    public void resetHighlights() 
-    {
+    /** */
+    public void resetHighlights() {
         initHighlightState();
         repaint();
     }

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -34,12 +34,14 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * This is the Subsequence view for the TutoringSession View. The title, words, and button are
- * displayed. Both words entered to find LCS are shown with the length of each. When the button is
- * pressed, it will display a step-by-step process to finding the LCS and highlight them
- * accordingly.
+ * This is the Subsequence view for the TutoringSession View. 
+ * 
+ * <p> Displays the current LCS inputs (x, y) and renders a canvas that highlights 
+ * characters belonging to the LCS as the alg executes. Highlighting is
+ * driven by model updates (ProblemListener), specifically when BACKTRACKING
  *
  * @author Sofia Reyes
+ * Most recent updates Feb 15, 2026 Lindsey C
  */
 class SubSequenceView extends JPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(SubSequenceView.class);
@@ -50,6 +52,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
     private static final int MAX_CANVAS_WIDTH = 4000;
     private static final int CANV_HORIZONTAL_PADDING = 40;
     private static final int DEFAULT_CANV_HEIGHT = 300;
+    //cache the last displayed words so we only reset the canvas when inputs truly change
+    //prevents per-step model updates from clearing previously highlighted characters
+    private String lastX = null;
+    private String lastY = null;
 
     private JLabel titleLabel, lengthLabel1, lengthLabel2, wordLabel1, wordLabel2;
     private JButton stepButton;
@@ -83,9 +89,6 @@ class SubSequenceView extends JPanel implements ProblemListener {
 
         lengthLabel2 = new JLabel();
         lengthLabel2.setFont(new Font("Dialog", Font.PLAIN, 16));
-
-        stepButton = new JButton("Step LCS");
-        stepButton.addActionListener(e -> stepThroughLCS());
 
         canvas = new SubSequenceCanvasView("word1", "word2");
     }
@@ -133,31 +136,12 @@ class SubSequenceView extends JPanel implements ProblemListener {
         canvasScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
 
         canvasScrollPane.getViewport().setBackground(Color.WHITE);
-        // Button added
-        JPanel buttonPanel = new JPanel(new FlowLayout());
-        buttonPanel.add(stepButton);
+        //removed old "Step LCS" button. Highlighting is now driven by the model during
+        //execution/backtracking (ProblemListener updates), not manual stepping in this view
 
         add(topPanel, BorderLayout.NORTH);
         add(canvasScrollPane, BorderLayout.CENTER);
-        add(buttonPanel, BorderLayout.SOUTH);
     }
-
-    // Button trigger
-    private void stepThroughLCS() {
-        canvas.highlightLCS();
-    }
-
-    //    public void setModel(Problem currentProblem) {
-    //        if (currentProblem != null && currentProblem instanceof LCSProblem) {
-    //            this.updateWords(
-    //                    ((LCSProblem) currentProblem).getX(), ((LCSProblem)
-    // currentProblem).getY());
-    //
-    //            setVisible(true);
-    //        } else if (currentProblem == null) {
-    //            setVisible(false);
-    //        }
-    //    }
 
     /**
      * Updates the displayed input strings and lengths when new inputs are submitted.
@@ -165,9 +149,12 @@ class SubSequenceView extends JPanel implements ProblemListener {
      * <p>Changes (April 17, 2025): - Dynamically updates all labels and canvas contents. - Forces
      * revalidation and repaint to ensure view reflects new inputs.
      *
-     * <p>TODO: In the future, improve resizing to dynamically fit very long words.
+     * <p>Note: Updating the inputs resets the canvas highlight state. During normal step
+     * execution the inputs do not change, so highlights persist across model updates
      *
      * @author EverettCV
+     * Recently updated 2/15/2026 Lindsey C
+     * 
      * @param word1 Updated first string input
      * @param word2 Updated second string input
      */
@@ -203,8 +190,9 @@ class SubSequenceView extends JPanel implements ProblemListener {
         if (canvas.getPreferredSize() != null) desiredHeight = canvas.getPreferredSize().height;
 
         canvas.setPreferredSize(new Dimension(desiredWidth, desiredHeight));
-        canvas.revalidate();
-        canvas.repaint();
+        // Parent revalidate/repaint at the end will refresh the canvas; avoid redundant calls here.
+        //canvas.revalidate();
+        //canvas.repaint();
 
         if (canvasScrollPane != null) canvasScrollPane.revalidate();
 
@@ -221,6 +209,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
     public void setModel(Problem model) {
 
         this.model = model;
+        //Reset cached input tracking when we bind a new model so the first updateView()
+        //call refreshes labels/canvas.
+        lastX = null;
+        lastY = null;
 
         if (this.model != null) {
 
@@ -255,8 +247,19 @@ class SubSequenceView extends JPanel implements ProblemListener {
      * Refresh the words displayed in this view based on the model. If the model is an LCSProblem,
      * extract x and y strings. Push those strings into updateWords(), which updates the labels and
      * canvas. For non-LCS problems, log but skip the update.
+     * 
+     * <p>Two independent concerns happen here:
+     * <ul>
+     *      <li>If x/y changed, update labels + reset canvas highlight state via updateWords().<li>
+     *      <li>If the model reports a committed LCS match (during backtracking), apply a persistent
+     *          highlight to the canvas at the reported indices.<li>
+     * <ul>
+     * 
+     * <p>We cache lastX/lastY so per-step model updates do not repeatedly reset the canvas
+     * (which would erase previously highlighted chars)
      *
      * @author hsherwin@regis.edu
+     * Last updated 2/15/2026 Lindsey C
      */
     private void updateView() {
         if (model instanceof LCSProblem lcs) {
@@ -264,8 +267,24 @@ class SubSequenceView extends JPanel implements ProblemListener {
             String x = (lcs.getX() == null) ? "" : lcs.getX();
             String y = (lcs.getY() == null) ? "" : lcs.getY();
 
-            // Update the view with the current words.
-            updateWords(x, y);
+            boolean wordsChanged = !x.equals(lastX) || !y.equals(lastY);
+            if (wordsChanged) {
+                log.debug("SubSequenceView: words changed; updating labels/canvas");
+                updateWords(x, y);
+                lastX = x;
+                lastY = y;
+            }
+
+            //Apply the most recently committed solution match from the model (if any).
+            //Indices are 0-based string positions (not DP table coordinates).
+            int mx = lcs.getLastMatchX();
+            int my = lcs.getLastMatchY();
+            log.debug("SubSequenceView: lastMatchX={}, lastMatchY={}", mx, my);
+
+            if (mx >= 0 && my >= 0) {
+                log.debug("SubSequenceView: applying highlightAt({}, {})", mx, my);
+                canvas.highlightAt(mx, my);
+            }
         } else if (model != null) {
             log.debug("SubSequenceView: model is not LCSProblem; " + "no word update performed");
         }

--- a/src/main/java/edu/regis/dptu/view/SubSequenceView.java
+++ b/src/main/java/edu/regis/dptu/view/SubSequenceView.java
@@ -34,14 +34,13 @@ import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemListener;
 
 /**
- * This is the Subsequence view for the TutoringSession View. 
- * 
- * <p> Displays the current LCS inputs (x, y) and renders a canvas that highlights 
- * characters belonging to the LCS as the alg executes. Highlighting is
- * driven by model updates (ProblemListener), specifically when BACKTRACKING
+ * This is the Subsequence view for the TutoringSession View.
  *
- * @author Sofia Reyes
- * Most recent updates Feb 15, 2026 Lindsey C
+ * <p>Displays the current LCS inputs (x, y) and renders a canvas that highlights characters
+ * belonging to the LCS as the alg executes. Highlighting is driven by model updates
+ * (ProblemListener), specifically when BACKTRACKING
+ *
+ * @author Sofia Reyes Most recent updates Feb 15, 2026 Lindsey C
  */
 class SubSequenceView extends JPanel implements ProblemListener {
     private static final Logger log = LoggerFactory.getLogger(SubSequenceView.class);
@@ -52,8 +51,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
     private static final int MAX_CANVAS_WIDTH = 4000;
     private static final int CANV_HORIZONTAL_PADDING = 40;
     private static final int DEFAULT_CANV_HEIGHT = 300;
-    //cache the last displayed words so we only reset the canvas when inputs truly change
-    //prevents per-step model updates from clearing previously highlighted characters
+    // cache the last displayed words so we only reset the canvas when inputs truly change
+    // prevents per-step model updates from clearing previously highlighted characters
     private String lastX = null;
     private String lastY = null;
 
@@ -136,8 +135,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
         canvasScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
 
         canvasScrollPane.getViewport().setBackground(Color.WHITE);
-        //removed old "Step LCS" button. Highlighting is now driven by the model during
-        //execution/backtracking (ProblemListener updates), not manual stepping in this view
+        // removed old "Step LCS" button. Highlighting is now driven by the model during
+        // execution/backtracking (ProblemListener updates), not manual stepping in this view
 
         add(topPanel, BorderLayout.NORTH);
         add(canvasScrollPane, BorderLayout.CENTER);
@@ -149,12 +148,10 @@ class SubSequenceView extends JPanel implements ProblemListener {
      * <p>Changes (April 17, 2025): - Dynamically updates all labels and canvas contents. - Forces
      * revalidation and repaint to ensure view reflects new inputs.
      *
-     * <p>Note: Updating the inputs resets the canvas highlight state. During normal step
-     * execution the inputs do not change, so highlights persist across model updates
+     * <p>Note: Updating the inputs resets the canvas highlight state. During normal step execution
+     * the inputs do not change, so highlights persist across model updates
      *
-     * @author EverettCV
-     * Recently updated 2/15/2026 Lindsey C
-     * 
+     * @author EverettCV Recently updated 2/15/2026 Lindsey C
      * @param word1 Updated first string input
      * @param word2 Updated second string input
      */
@@ -191,8 +188,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
 
         canvas.setPreferredSize(new Dimension(desiredWidth, desiredHeight));
         // Parent revalidate/repaint at the end will refresh the canvas; avoid redundant calls here.
-        //canvas.revalidate();
-        //canvas.repaint();
+        // canvas.revalidate();
+        // canvas.repaint();
 
         if (canvasScrollPane != null) canvasScrollPane.revalidate();
 
@@ -209,8 +206,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
     public void setModel(Problem model) {
 
         this.model = model;
-        //Reset cached input tracking when we bind a new model so the first updateView()
-        //call refreshes labels/canvas.
+        // Reset cached input tracking when we bind a new model so the first updateView()
+        // call refreshes labels/canvas.
         lastX = null;
         lastY = null;
 
@@ -247,19 +244,20 @@ class SubSequenceView extends JPanel implements ProblemListener {
      * Refresh the words displayed in this view based on the model. If the model is an LCSProblem,
      * extract x and y strings. Push those strings into updateWords(), which updates the labels and
      * canvas. For non-LCS problems, log but skip the update.
-     * 
-     * <p>Two independent concerns happen here:
-     * <ul>
-     *      <li>If x/y changed, update labels + reset canvas highlight state via updateWords().<li>
-     *      <li>If the model reports a committed LCS match (during backtracking), apply a persistent
-     *          highlight to the canvas at the reported indices.<li>
-     * <ul>
-     * 
-     * <p>We cache lastX/lastY so per-step model updates do not repeatedly reset the canvas
-     * (which would erase previously highlighted chars)
      *
-     * @author hsherwin@regis.edu
-     * Last updated 2/15/2026 Lindsey C
+     * <p>Two independent concerns happen here:
+     *
+     * <ul>
+     *   <li>If x/y changed, update labels + reset canvas highlight state via updateWords().
+     *   <li>
+     *   <li>If the model reports a committed LCS match (during backtracking), apply a persistent
+     *       highlight to the canvas at the reported indices.
+     *   <li>
+     *       <ul>
+     *         <p>We cache lastX/lastY so per-step model updates do not repeatedly reset the canvas
+     *         (which would erase previously highlighted chars)
+     *
+     * @author hsherwin@regis.edu Last updated 2/15/2026 Lindsey C
      */
     private void updateView() {
         if (model instanceof LCSProblem lcs) {
@@ -275,8 +273,8 @@ class SubSequenceView extends JPanel implements ProblemListener {
                 lastY = y;
             }
 
-            //Apply the most recently committed solution match from the model (if any).
-            //Indices are 0-based string positions (not DP table coordinates).
+            // Apply the most recently committed solution match from the model (if any).
+            // Indices are 0-based string positions (not DP table coordinates).
             int mx = lcs.getLastMatchX();
             int my = lcs.getLastMatchY();
             log.debug("SubSequenceView: lastMatchX={}, lastMatchY={}", mx, my);


### PR DESCRIPTION
This PR removes the manual “highlight” button and moves all LCS string highlighting to be driven directly by the algorithm’s execution.

Highlighting now occurs when the backtracking phase commits characters into the LCS solution, ensuring that only characters that are actually part of the final LCS are highlighted (rather than incidental matches during DP table fill). Backtracking execution was enabled so that both the DP table and the input strings are highlighted consistently as the solution path is traced.

This aligns the highlighting with the actual LCS algorithm and improves the instructional clarity