### PR TITLE
DPTU-165: Initialize PendingTask for SeeOne sessions and fix tskId resolution

### DIFF
--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -104,7 +104,10 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 problem.setTitle(rs.getString(3));
                 problem.setDescription(rs.getString(4));
 
-                log.debug("Problem retrieved successfully for kind={}", kind);
+                int taskId = retrieveTaskIdForProblem(problem.getId(), conn);
+                problem.setTaskId(taskId);
+
+                log.debug("Problem retrieved successfully for kind={}, taskId={}", kind, taskId);
                 return problem;
             } else {
                 log.warn("No problem found for kind={}", kind);
@@ -179,6 +182,44 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
             throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
         } finally {
             close(stmt); // Don't close the connection, retrieve(courseId) will
+        }
+    }
+
+    /**
+     * Retrieve the TaskId for the Task that represents the given Problem.
+     *
+     * @param problemId the id of the problem
+     * @param conn open database connection
+     * @return the task id, or -1 if no matching task exists
+     * @throws NonRecoverableException if the query fails
+     */
+    private int retrieveTaskIdForProblem(int problemId, Connection conn)
+            throws NonRecoverableException {
+        final String sql = "SELECT TaskId FROM Task WHERE Kind = ? AND KindId = ?";
+
+        PreparedStatement stmt = null;
+
+        try {
+            stmt = conn.prepareStatement(sql);
+            stmt.setString(1, "PROBLEM");
+            stmt.setInt(2, problemId);
+
+            ResultSet rs = stmt.executeQuery();
+
+            if (rs.next()) {
+                int taskId = rs.getInt(1);
+                log.debug("Found taskId={} for problemId={}", taskId, problemId);
+                return taskId;
+            }
+
+            log.warn("No Task found for problemId={}", problemId);
+            return -1;
+
+        } catch (SQLException e) {
+            log.error("SQLException retrieving taskId for problemId={}", problemId, e);
+            throw new NonRecoverableException("ProblemDAO-ERR-taskLookup " + e.toString(), e);
+        } finally {
+            close(stmt);
         }
     }
 }

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -159,6 +159,10 @@ public class TutoringSession {
     }
 
     public PendingTask getCurrentTask() {
+        if (tasks == null || tasks.isEmpty()) {
+            log.warn("Session {} has no current tasks", userId);
+            return null;
+        }
         return tasks.get(0);
     }
 
@@ -185,6 +189,7 @@ public class TutoringSession {
         tasks.removeIf(task -> task.getTask().getId() == taskId);
         log.debug("Session {} removed task with id={}", userId, taskId);
     }
+
 
     public Mode getMode() {
         return mode;

--- a/src/main/java/edu/regis/dptu/model/TutoringSession.java
+++ b/src/main/java/edu/regis/dptu/model/TutoringSession.java
@@ -190,7 +190,6 @@ public class TutoringSession {
         log.debug("Session {} removed task with id={}", userId, taskId);
     }
 
-
     public Mode getMode() {
         return mode;
     }

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -19,13 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.PendingTask;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.svc.ClientRequest;
 import edu.regis.dptu.svc.ServerRequestType;
 import edu.regis.dptu.svc.SvcFacade;
 import edu.regis.dptu.svc.TutorReply;
 import edu.regis.dptu.svc.TutorSvc;
-import edu.regis.dptu.model.PendingTask;
 
 /**
  * Displays a tutoring session (the top-level GUI view for the application). Integrates views and
@@ -109,19 +109,16 @@ public class TutoringSessionView extends GPanel {
                             // TaskId comes from the current task in session
                             PendingTask currentTask = model.getCurrentTask();
                             if (currentTask == null || currentTask.getTask() == null) {
-                                log.warn("No current task available in session; cannot send CompletedTask);");
+                                log.warn(
+                                        "No current task available in session; cannot send CompletedTask);");
                                 return;
                             }
 
                             /**
-                             * if (model.getTasks().isEmpty()) {
-                                log.warn(
-                                        "No current task available/no problem in session; cannot send CompletedTask");
-                                return;
-                            }
+                             * if (model.getTasks().isEmpty()) { log.warn( "No current task
+                             * available/no problem in session; cannot send CompletedTask"); return;
+                             * }
                              */
-
-
                             int taskId = model.getProblem().getTaskId();
                             if (taskId < 0) {
                                 log.warn(

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -25,6 +25,7 @@ import edu.regis.dptu.svc.ServerRequestType;
 import edu.regis.dptu.svc.SvcFacade;
 import edu.regis.dptu.svc.TutorReply;
 import edu.regis.dptu.svc.TutorSvc;
+import edu.regis.dptu.model.PendingTask;
 
 /**
  * Displays a tutoring session (the top-level GUI view for the application). Integrates views and
@@ -106,11 +107,20 @@ public class TutoringSessionView extends GPanel {
                             String token = model.getSecurityToken();
 
                             // TaskId comes from the current task in session
-                            if (model.getTasks().isEmpty()) {
+                            PendingTask currentTask = model.getCurrentTask();
+                            if (currentTask == null || currentTask.getTask() == null) {
+                                log.warn("No current task available in session; cannot send CompletedTask);");
+                                return;
+                            }
+
+                            /**
+                             * if (model.getTasks().isEmpty()) {
                                 log.warn(
                                         "No current task available/no problem in session; cannot send CompletedTask");
                                 return;
                             }
+                             */
+
 
                             int taskId = model.getProblem().getTaskId();
                             if (taskId < 0) {

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -29,6 +29,8 @@ import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.util.ResourceMgr;
 import edu.regis.dptu.view.DashboardPanel;
 import edu.regis.dptu.view.SplashFrame;
+import edu.regis.dptu.model.Task;
+import edu.regis.dptu.model.PendingTask;
 
 public class SeeOneAction extends DpTuGuiAction {
     private static final Logger log = LoggerFactory.getLogger(SeeOneAction.class);
@@ -84,6 +86,24 @@ public class SeeOneAction extends DpTuGuiAction {
 
             TutoringSession ts = new TutoringSession(account, problem);
             ts.setMode(Mode.SEE_ONE);
+            
+            int taskId = problem.getTaskId();
+            if (taskId < 0) {
+                log.warn("SEE_ONE session created with invalid problem.taskId={}", taskId);
+            } else {
+                Task task = new Task(taskId);
+                task.setProblem(problem);
+                PendingTask pendingTask = new PendingTask(task);
+                ts.addTask(pendingTask);
+                /**
+                 * If some later code expects the PendingTask to also have a current step we might 
+                 * need smth like this:
+                 * if (task.getCurrentStep() != null) {
+                    pendingTask.setCurrentStep(new PendingStep(task.getCurrentStep()));
+                    }
+                 */
+                log.info("Initialized SEE_ONE session with PendingTask taskId={}", taskId);
+            }
 
             SplashFrame.instance().selectLessonScreen(ts);
 

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -23,14 +23,14 @@ import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.PendingTask;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
+import edu.regis.dptu.model.Task;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.util.ResourceMgr;
 import edu.regis.dptu.view.DashboardPanel;
 import edu.regis.dptu.view.SplashFrame;
-import edu.regis.dptu.model.Task;
-import edu.regis.dptu.model.PendingTask;
 
 public class SeeOneAction extends DpTuGuiAction {
     private static final Logger log = LoggerFactory.getLogger(SeeOneAction.class);
@@ -86,7 +86,7 @@ public class SeeOneAction extends DpTuGuiAction {
 
             TutoringSession ts = new TutoringSession(account, problem);
             ts.setMode(Mode.SEE_ONE);
-            
+
             int taskId = problem.getTaskId();
             if (taskId < 0) {
                 log.warn("SEE_ONE session created with invalid problem.taskId={}", taskId);
@@ -96,11 +96,9 @@ public class SeeOneAction extends DpTuGuiAction {
                 PendingTask pendingTask = new PendingTask(task);
                 ts.addTask(pendingTask);
                 /**
-                 * If some later code expects the PendingTask to also have a current step we might 
-                 * need smth like this:
-                 * if (task.getCurrentStep() != null) {
-                    pendingTask.setCurrentStep(new PendingStep(task.getCurrentStep()));
-                    }
+                 * If some later code expects the PendingTask to also have a current step we might
+                 * need smth like this: if (task.getCurrentStep() != null) {
+                 * pendingTask.setCurrentStep(new PendingStep(task.getCurrentStep())); }
                  */
                 log.info("Initialized SEE_ONE session with PendingTask taskId={}", taskId);
             }


### PR DESCRIPTION
Added logic in SeeOneAction to initialize a PendingTask when creating a TutoringSession Updated TutoringSessionView to use getCurrentTask() as the source of truth instead of directly accessing the task list Made TutoringSession.getCurrentTask() null-safe
Fixed missing taskId by resolving it in ProblemDAO.retrieveByKind(...) using the Task table

This resolves the issue where sessions had no current task and completion events could not be sent.

Note: COMPLETED_TASK requests are now triggered correctly, but currently fail due to missing session security token. This will be addressed in a follow-up PR.

Additionally, need to add the same SessionTask initializing in the code for DoOne and TeachOne, as simple as copy and paste, will do in a follow-up PR