### PR TITLE
Fixed Formatting Issues

### DIFF
--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -86,8 +86,7 @@ public class DashboardPanel extends GPanel {
     /* Greets user by name in JOptionPanne and dashboard header. */
     public void setFirstName(String firstName) {
         this.firstName = firstName;
-        welcomeLabel.setText(
-                String.format(ResourceMgr.instance().string("dashboard.welcome"), firstName));
+        welcomeLabel.setText(ResourceMgr.instance().string("dashboard.welcome", firstName));
         displayWelcomeDialog();
     }
 
@@ -116,10 +115,7 @@ public class DashboardPanel extends GPanel {
         settingsButton = new JButton(ResourceMgr.instance().string("dashboard.button.settings"));
         settingsButton.setFocusPainted(false);
 
-        welcomeLabel =
-                new JLabel(
-                        String.format(
-                                ResourceMgr.instance().string("dashboard.welcome"), firstName));
+        welcomeLabel = new JLabel(ResourceMgr.instance().string("dashboard.welcome", firstName));
         welcomeLabel.setForeground(FILL);
         welcomeLabel.setHorizontalAlignment(SwingConstants.CENTER);
         welcomeLabel.setFont(new Font("Segoe UI", Font.PLAIN, 18));
@@ -243,10 +239,7 @@ public class DashboardPanel extends GPanel {
     }
 
     private void displayWelcomeDialog() {
-        String welcomeMessage =
-                String.format(
-                        ResourceMgr.instance().string("dashboard.welcome.sessionStarted"),
-                        firstName);
+        String welcomeMessage = ResourceMgr.instance().string("dashboard.welcome.sessionStarted", firstName);
         JOptionPane.showMessageDialog(
                 null,
                 welcomeMessage,

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -239,7 +239,8 @@ public class DashboardPanel extends GPanel {
     }
 
     private void displayWelcomeDialog() {
-        String welcomeMessage = ResourceMgr.instance().string("dashboard.welcome.sessionStarted", firstName);
+        String welcomeMessage =
+                ResourceMgr.instance().string("dashboard.welcome.sessionStarted", firstName);
         JOptionPane.showMessageDialog(
                 null,
                 welcomeMessage,


### PR DESCRIPTION
`DashboardPanel` was incorrectly using `String.format()` to try to format the curly brace format style `{0}`, which caused the message "Welcome {0}!" to be displayed to the user rather than showing their first name. This PR fixes this issue, and I verified that this doesn't happen elsewhere in the code, since the only other uses of `String.format()` are necessary to display integers with specific widths, which `MessageFormat.format()` doesn't support.

This might be blocked until my previous change in branch `DPTU-100` is merged, since that also fixes a failing unit test.