### PR TITLE
Only allow one instance of StatsWindow to be open at a time

### DIFF
--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -25,7 +25,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Arrays;
@@ -163,18 +162,24 @@ public class DashboardPanel extends GPanel {
                 new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         seeOneStatsButton.setFocusPainted(false);
         seeOneStatsButton.addActionListener(
-                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.seeOne.title")));
+                e ->
+                        statsButtonActionPerformed(
+                                ResourceMgr.instance().string("dashboard.stats.seeOne.title")));
 
         doOneStatsButton = new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         doOneStatsButton.setFocusPainted(false);
         doOneStatsButton.addActionListener(
-                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.doOne.title")));
+                e ->
+                        statsButtonActionPerformed(
+                                ResourceMgr.instance().string("dashboard.stats.doOne.title")));
 
         teachOneStatsButton =
                 new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         teachOneStatsButton.setFocusPainted(false);
         teachOneStatsButton.addActionListener(
-                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.teachOne.title")));
+                e ->
+                        statsButtonActionPerformed(
+                                ResourceMgr.instance().string("dashboard.stats.teachOne.title")));
 
         // Apply scaffold level rules for which buttons are visible.
         applyScaffoldLevelRules();
@@ -278,9 +283,11 @@ public class DashboardPanel extends GPanel {
     }
 
     /**
-     * This function runs when any of the stats buttons are clicked, and handles creating and opening the respective stats window.
-     * It sets a flag when the window is successfully created, so that multiple windows can't be open at once, and resets the flag when the window is closed.
-     * 
+     * This function runs when any of the stats buttons are clicked, and handles creating and
+     * opening the respective stats window. It sets a flag when the window is successfully created,
+     * so that multiple windows can't be open at once, and resets the flag when the window is
+     * closed.
+     *
      * @param title The title used for this stats window
      */
     private void statsButtonActionPerformed(String title) {
@@ -296,8 +303,7 @@ public class DashboardPanel extends GPanel {
                                 isStatsOpen = false;
                             }
                         });
-            }
-            catch (RuntimeException e) {
+            } catch (RuntimeException e) {
                 log.error("Failed to create stats window", e);
             }
         } else {

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -25,6 +25,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Arrays;
@@ -162,75 +163,18 @@ public class DashboardPanel extends GPanel {
                 new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         seeOneStatsButton.setFocusPainted(false);
         seeOneStatsButton.addActionListener(
-                e -> {
-                    log.info("See One Stats button pressed, isStatsOpen = {}", isStatsOpen);
-                    if (!isStatsOpen) {
-                        log.info("See One Stats window opened");
-                        isStatsOpen = true;
-                        StatsWindow statsWindow =
-                                new StatsWindow(
-                                        ResourceMgr.instance()
-                                                .string("dashboard.stats.seeOne.title"));
-                        statsWindow.addWindowListener(
-                                new WindowAdapter() {
-                                    public void windowClosing(WindowEvent e) {
-                                        log.info("See One Stats window closing");
-                                        isStatsOpen = false;
-                                    }
-                                });
-                    } else {
-                        log.info("Another Stats window is already opened");
-                    }
-                });
+                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.seeOne.title")));
 
         doOneStatsButton = new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         doOneStatsButton.setFocusPainted(false);
         doOneStatsButton.addActionListener(
-                e -> {
-                    log.info("Do One Stats button pressed, isStatsOpen = {}", isStatsOpen);
-                    if (!isStatsOpen) {
-                        log.info("Do One Stats window opened");
-                        isStatsOpen = true;
-                        StatsWindow statsWindow =
-                                new StatsWindow(
-                                        ResourceMgr.instance()
-                                                .string("dashboard.stats.doOne.title"));
-                        statsWindow.addWindowListener(
-                                new WindowAdapter() {
-                                    public void windowClosing(WindowEvent e) {
-                                        log.info("Do One Stats window closing");
-                                        isStatsOpen = false;
-                                    }
-                                });
-                    } else {
-                        log.info("Another Stats window is already opened");
-                    }
-                });
+                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.doOne.title")));
 
         teachOneStatsButton =
                 new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         teachOneStatsButton.setFocusPainted(false);
         teachOneStatsButton.addActionListener(
-                e -> {
-                    log.info("Teach One Stats button pressed, isStatsOpen = {}", isStatsOpen);
-                    if (!isStatsOpen) {
-                        log.info("Teach One Stats window opened");
-                        isStatsOpen = true;
-                        StatsWindow statsWindow =
-                                new StatsWindow(
-                                        ResourceMgr.instance()
-                                                .string("dashboard.stats.teachOne.title"));
-                        statsWindow.addWindowListener(
-                                new WindowAdapter() {
-                                    public void windowClosing(WindowEvent e) {
-                                        log.info("Teach One Stats window closing");
-                                        isStatsOpen = false;
-                                    }
-                                });
-                    } else {
-                        log.info("Another Stats window is already opened");
-                    }
-                });
+                e -> statsButtonActionPerformed(ResourceMgr.instance().string("dashboard.stats.teachOne.title")));
 
         // Apply scaffold level rules for which buttons are visible.
         applyScaffoldLevelRules();
@@ -331,6 +275,34 @@ public class DashboardPanel extends GPanel {
 
     private void logOutButtonActionPerformed(java.awt.event.ActionEvent evt) {
         SplashFrame.instance().logout();
+    }
+
+    /**
+     * This function runs when any of the stats buttons are clicked, and handles creating and opening the respective stats window.
+     * It sets a flag when the window is successfully created, so that multiple windows can't be open at once, and resets the flag when the window is closed.
+     * 
+     * @param title The title used for this stats window
+     */
+    private void statsButtonActionPerformed(String title) {
+        if (!isStatsOpen) {
+            try {
+                StatsWindow statsWindow = new StatsWindow(title);
+                log.info("{} window opened", title);
+                isStatsOpen = true;
+                statsWindow.addWindowListener(
+                        new WindowAdapter() {
+                            public void windowClosed(WindowEvent e) {
+                                log.info("{} window closing", title);
+                                isStatsOpen = false;
+                            }
+                        });
+            }
+            catch (RuntimeException e) {
+                log.error("Failed to create stats window", e);
+            }
+        } else {
+            log.info("Another Stats window is already opened");
+        }
     }
 
     /**

--- a/src/main/java/edu/regis/dptu/view/DashboardPanel.java
+++ b/src/main/java/edu/regis/dptu/view/DashboardPanel.java
@@ -25,6 +25,8 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Arrays;
 
 import javax.swing.BorderFactory;
@@ -69,6 +71,8 @@ public class DashboardPanel extends GPanel {
     private CustomProgressBar teachOneProgressBar;
     private JLabel welcomeLabel;
     private JComboBox<String> problemSelector; // @author EverettCV
+
+    private static boolean isStatsOpen = false;
 
     private static final Color BACKGROUND = new Color(32, 88, 96); // dark seafoam green
     private static final Color TEXT = new Color(31, 41, 55); // deep charcoal
@@ -159,16 +163,48 @@ public class DashboardPanel extends GPanel {
         seeOneStatsButton.setFocusPainted(false);
         seeOneStatsButton.addActionListener(
                 e -> {
-                    log.info("See One Stats button pressed");
-                    new StatsWindow(ResourceMgr.instance().string("dashboard.stats.seeOne.title"));
+                    log.info("See One Stats button pressed, isStatsOpen = {}", isStatsOpen);
+                    if (!isStatsOpen) {
+                        log.info("See One Stats window opened");
+                        isStatsOpen = true;
+                        StatsWindow statsWindow =
+                                new StatsWindow(
+                                        ResourceMgr.instance()
+                                                .string("dashboard.stats.seeOne.title"));
+                        statsWindow.addWindowListener(
+                                new WindowAdapter() {
+                                    public void windowClosing(WindowEvent e) {
+                                        log.info("See One Stats window closing");
+                                        isStatsOpen = false;
+                                    }
+                                });
+                    } else {
+                        log.info("Another Stats window is already opened");
+                    }
                 });
 
         doOneStatsButton = new JButton(ResourceMgr.instance().string("dashboard.button.viewStats"));
         doOneStatsButton.setFocusPainted(false);
         doOneStatsButton.addActionListener(
                 e -> {
-                    log.info("Do One Stats button pressed");
-                    new StatsWindow(ResourceMgr.instance().string("dashboard.stats.doOne.title"));
+                    log.info("Do One Stats button pressed, isStatsOpen = {}", isStatsOpen);
+                    if (!isStatsOpen) {
+                        log.info("Do One Stats window opened");
+                        isStatsOpen = true;
+                        StatsWindow statsWindow =
+                                new StatsWindow(
+                                        ResourceMgr.instance()
+                                                .string("dashboard.stats.doOne.title"));
+                        statsWindow.addWindowListener(
+                                new WindowAdapter() {
+                                    public void windowClosing(WindowEvent e) {
+                                        log.info("Do One Stats window closing");
+                                        isStatsOpen = false;
+                                    }
+                                });
+                    } else {
+                        log.info("Another Stats window is already opened");
+                    }
                 });
 
         teachOneStatsButton =
@@ -176,9 +212,24 @@ public class DashboardPanel extends GPanel {
         teachOneStatsButton.setFocusPainted(false);
         teachOneStatsButton.addActionListener(
                 e -> {
-                    log.info("Teach One Stats button pressed");
-                    new StatsWindow(
-                            ResourceMgr.instance().string("dashboard.stats.teachOne.title"));
+                    log.info("Teach One Stats button pressed, isStatsOpen = {}", isStatsOpen);
+                    if (!isStatsOpen) {
+                        log.info("Teach One Stats window opened");
+                        isStatsOpen = true;
+                        StatsWindow statsWindow =
+                                new StatsWindow(
+                                        ResourceMgr.instance()
+                                                .string("dashboard.stats.teachOne.title"));
+                        statsWindow.addWindowListener(
+                                new WindowAdapter() {
+                                    public void windowClosing(WindowEvent e) {
+                                        log.info("Teach One Stats window closing");
+                                        isStatsOpen = false;
+                                    }
+                                });
+                    } else {
+                        log.info("Another Stats window is already opened");
+                    }
                 });
 
         // Apply scaffold level rules for which buttons are visible.


### PR DESCRIPTION
Add a boolean variable to DashboardPanel and listeners to the opening and closing the the StatsWindows to prevent multiple StatsWindows from being open at once.

This was tested by opening the See One Stats Window, and then trying to open another instance of the stats window for See One, Do One, and Teach One, and then making sure stats windows could be opened after the instance of the See One stats window was closed. This process was then repeated for the Do One and Teach One stats windows.

I also tested that the current functionality of the stats windows wasn't broken, which currently only includes opening the window and displaying the correct title based on which button was clicked.