### PR TITLE
Fix format workflow push for pull_request runs

### DIFF
--- a/.github/workflows/format-build-test.yml
+++ b/.github/workflows/format-build-test.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
     - name: Set up JDK 17 (with Maven cache)
       uses: actions/setup-java@v4
@@ -83,7 +84,7 @@ jobs:
         git config --local user.name "GitHub Action"
         git add .
         git commit -m "Auto-format code with Spotless"
-        git push
+        git push origin HEAD:${{ github.head_ref }}
 
   build:
     needs: format


### PR DESCRIPTION
## Summary
- ensure the `format` job checks out the PR head branch when running on `pull_request`
- push Spotless auto-format commits explicitly back to the PR head branch

## Why
PR checks were failing in the `format` job with exit code 128 because the job could run from a detached HEAD and then attempt a plain `git push`.

## Changes
- `.github/workflows/format-build-test.yml`
  - set `ref` on the format job checkout step to use PR head branch for pull requests
  - change push command to `git push origin HEAD:${{ github.head_ref }}`

## Validation
- branch pushed: `DPTU-106-workflow-fix`
- this PR updates only the workflow file
