### PR TITLE
Fix format workflow git push for PR branch

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -52,4 +52,4 @@ jobs:
         git config --local user.name "GitHub Action"
         git add .
         git commit -m "Auto-format code with Spotless"
-        git push
+        git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- Update format workflow push command to explicitly target the PR head branch.

## Why
PR #155 shows `format` check failure with `Process completed with exit code 128`.
The workflow commits formatting changes and then runs plain `git push`, which can fail in CI when no upstream is configured for the checked-out branch context.

## Change
- `.github/workflows/format-code.yml`
  - `git push` -> `git push origin HEAD:${{ github.head_ref }}`

## Scope
- Workflow-only change.
- No application code changes.
