### PR TITLE
Added MatrixChainProblem See One Functionality

### DIFF
--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -293,7 +293,7 @@ VALUES
   (1, 'Matrix Chain: See One', 
    'In this unit, the student will see an example of a Dynamic Programming
    approach that solves a Matrix Chain Optimization problem for a sequence 
-   of matricies.', 
+   of matrices.', 
    0, 'FIXED_SEQUENCE');
 
 INSERT INTO Task
@@ -349,7 +349,7 @@ VALUES
 INSERT INTO LCSProblem
  (Id, Sequence1, Sequence2)
  VALUES
- (0, 'skulls', 'babies');
+ (0, 'skullandbones', 'lullabybabies');
 
 INSERT INTO MatrixChainProblem
  (Id)

--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -256,7 +256,7 @@ CREATE TABLE MatrixSizes (
   ProblemId INT NOT NULL,
   Width INT,
   Height INT,
-  PRIMARY KEY (SizeId),
+  PRIMARY KEY (ProblemId, SizeId),
   FOREIGN KEY (ProblemId) REFERENCES MatrixChainProblem(Id)
     ON UPDATE CASCADE ON DELETE CASCADE
 );

--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -245,13 +245,29 @@ CREATE TABLE LCSProblem (
   PRIMARY KEY (Id)
 );
 
+CREATE TABLE MatrixChainProblem (
+  Id INT NOT NULL,
+  PRIMARY KEY (Id)
+);
+
+-- A separate table for the matrix sizes is needed since SQL doesn't have arrays
+CREATE TABLE MatrixSizes (
+  SizeId INT NOT NULL,
+  ProblemId INT NOT NULL,
+  Width INT,
+  Height INT,
+  PRIMARY KEY (SizeId),
+  FOREIGN KEY (ProblemId) REFERENCES MatrixChainProblem(Id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 #records when a student completes a Task, per student
 # used to persist progress across sessions
 CREATE TABLE CompletedTask (
   UserId VARCHAR(256) NOT NULL,
   TaskId INT NOT NULL,
   CompletedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (UserId, TaskId)
+  PRIMARY KEY (UserId, TaskId),
    FOREIGN KEY (UserId)
       REFERENCES account(UserId)
 );
@@ -270,10 +286,15 @@ INSERT INTO Unit
   (CourseId, Title, Description, SequenceIndex, Pedagogy)
 VALUES
   (1, 'LCS: See One', 
-  'In this unit, the student will see an example of a Dynamic Programming
+   'In this unit, the student will see an example of a Dynamic Programming
    approach that solves a Longest Common Subsequence (LCS) problem for two
    string sequences.', 
-    0, 'FIXED_SEQUENCE');
+   0, 'FIXED_SEQUENCE'),
+  (1, 'Matrix Chain: See One', 
+   'In this unit, the student will see an example of a Dynamic Programming
+   approach that solves a Matrix Chain Optimization problem for a sequence 
+   of matricies.', 
+   0, 'FIXED_SEQUENCE');
 
 INSERT INTO Task
  (TaskId, CourseId, UnitId, SequenceIndex, Title,
@@ -282,7 +303,10 @@ INSERT INTO Task
  VALUES
  (0, 1, 1, 0, 'Problem Overview', 
   'Review the presentation of the current Dynamic Programming problem', 
-  'PROBLEM', 0);
+  'PROBLEM', 0),
+ (1, 1, 2, 0, 'Problem Overview',
+  'Review the presentation of the current Matrix Chain Dynamic Programming problem',
+  'PROBLEM', 1); -- Matrix Chain SEE ONE problem
 
 INSERT INTO Step 
  (Id, CourseId, UnitId, TaskId, SequenceIndex,
@@ -318,12 +342,30 @@ INSERT INTO Problem
  (Id, ProblemType, SubTypeId, Title, Description)
 VALUES
  (0, 'LCS_PROBLEM', 0, 'Longest Common Subsequence Problem 1',
-  'Determine the longests common subsequence for the given sequences/strings.');
+  'Determine the longest common subsequence for the given sequences/strings.'),
+ (1, 'MATRIX_CHAIN', 0, 'Matrix Chaining Problem 1',
+  'Determine the optimal number of operations in an optimal paranethization of the matrix sequence.');
 
 INSERT INTO LCSProblem
  (Id, Sequence1, Sequence2)
  VALUES
- (0, 'skullandbones', 'lullabybabies');
+ (0, 'skulls', 'babies');
+
+INSERT INTO MatrixChainProblem
+ (Id)
+ VALUES
+ (0);
+
+INSERT INTO MatrixSizes
+ (SizeId, ProblemId, Width, Height)
+ VALUES
+ -- ProblemId = 0: {10, 5}, {5, 2}, {2, 20}, {20, 12}, {12, 4}, {4, 60}
+ (0, 0, 10, 5 ),
+ (1, 0, 5,  2 ),
+ (2, 0, 2,  20),
+ (3, 0, 20, 12),
+ (4, 0, 12, 4 ),
+ (5, 0, 4,  60);
 
 /*********************************************************************************
 * Foreign Indexes

--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -294,7 +294,7 @@ VALUES
    'In this unit, the student will see an example of a Dynamic Programming
    approach that solves a Matrix Chain Optimization problem for a sequence 
    of matrices.', 
-   0, 'FIXED_SEQUENCE');
+   1, 'FIXED_SEQUENCE');
 
 INSERT INTO Task
  (TaskId, CourseId, UnitId, SequenceIndex, Title,
@@ -344,7 +344,7 @@ VALUES
  (0, 'LCS_PROBLEM', 0, 'Longest Common Subsequence Problem 1',
   'Determine the longest common subsequence for the given sequences/strings.'),
  (1, 'MATRIX_CHAIN', 0, 'Matrix Chaining Problem 1',
-  'Determine the optimal number of operations in an optimal paranethization of the matrix sequence.');
+  'Determine the optimal number of operations in an optimal parenthesization of the matrix sequence.');
 
 INSERT INTO LCSProblem
  (Id, Sequence1, Sequence2)

--- a/documentation/DATABASE_SCHEMA.md
+++ b/documentation/DATABASE_SCHEMA.md
@@ -20,6 +20,8 @@ TABLE OF CONTENTS
 - Hint
 - KnowledgeComponent
 - LCSProblem
+- MatrixChainProblem
+- MatrixSizes
 - ExercisingLocation
 - Timeout
 - InfoMsgStep
@@ -133,6 +135,21 @@ Purpose: Stores input for Longest Common Subsequence problems.
 - Description: TEXT
 - Sequence1: TEXT [NOT NULL]
 - Sequence2: TEXT [NOT NULL]
+
+MATRIXCHAINPROBLEM
+
+Purpose: Stores input for Matrix Chain Optimization problems.
+
+- Id INT [PRIMARY KEY]
+
+MATRIXSIZES
+
+Purpose: Stores input on sizes of matrices for a specific Matrix Chain Optimization problem.
+
+- SizeId: INT [PRIMARY KEY]
+- ProblemId: INT [NOT NULL, FK to MatrixChainProblem(Id)]
+- Width: INT
+- Height: INT
 
 EXERCISING LOCATION
 

--- a/documentation/DATABASE_SCHEMA.md
+++ b/documentation/DATABASE_SCHEMA.md
@@ -140,7 +140,7 @@ MATRIXCHAINPROBLEM
 
 Purpose: Stores input for Matrix Chain Optimization problems.
 
-- Id INT [PRIMARY KEY]
+- Id: INT [PRIMARY KEY]
 
 MATRIXSIZES
 

--- a/documentation/DATABASE_SCHEMA.md
+++ b/documentation/DATABASE_SCHEMA.md
@@ -146,8 +146,9 @@ MATRIXSIZES
 
 Purpose: Stores input on sizes of matrices for a specific Matrix Chain Optimization problem.
 
-- SizeId: INT [PRIMARY KEY]
-- ProblemId: INT [NOT NULL, FK to MatrixChainProblem(Id)]
+- SizeId: INT [NOT NULL, PRIMARY KEY]
+  Position/index of this matrix size within the problem; unique only within a given ProblemId.
+- ProblemId: INT [NOT NULL, PRIMARY KEY, FK to MatrixChainProblem(Id)]
 - Width: INT
 - Height: INT
 

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -17,6 +17,9 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+
+import javax.sql.rowset.serial.SerialArray;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.MatrixChainProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.svc.ProblemSvc;
@@ -131,8 +135,9 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 return retrieveLCSProblem(id, subTypeId, conn);
 
             case MATRIX_CHAIN:
-                log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
-                return null;
+                // TODO: Implement retrieving Matrix Chain problem from the database
+                //log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
+                return retrieveMatrixChainProblem(id, subTypeId, conn);
 
             case KNAPSACK_0_1:
                 log.warn("KNAPSACK_0_1 retrieval not implemented for id={}", id);
@@ -180,6 +185,61 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
             }
         } catch (SQLException e) {
             log.error("SQLException retrieving LCSProblem id={}, subTypeId={}", id, subTypeId, e);
+            throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
+        } finally {
+            close(stmt); // Don't close the connection, retrieve(courseId) will
+        }
+    }
+    
+    /**
+     * 
+     * 
+     * @param id the id of the returned Matrix Chain problem
+     * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table
+     * @param conn an open connection to the DB, which isn't closed.
+     * @return a MatrixChainProblem with the given id and subTypeId
+     * @throws NonRecoverableException possible see getCause()
+     */
+    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn) throws NonRecoverableException {
+        log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
+        final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ?";
+        
+        PreparedStatement stmt = null;
+        
+        try {
+            stmt = conn.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            stmt.setInt(1, subTypeId);
+            
+            ResultSet rs = stmt.executeQuery();
+            
+            // Get the number of rows returned, then add each width and height to a numRows by 2 array for MatrixChainProblem
+            if (rs.last()){
+                int numRows = rs.getRow();
+                log.debug("Number of Matrices={}", numRows);
+                
+                int[][] sizes = new int[numRows][2];
+                rs.beforeFirst();
+                int i = 0;
+                while (rs.next()) {
+                    sizes[i][0] = rs.getInt(2);
+                    sizes[i][1] = rs.getInt(3);
+                    i++;
+                }
+                log.debug("Matrix Sizes Array={}", Arrays.toString(sizes));
+                for (int[] size : sizes) log.debug("Size={}", Arrays.toString(size));
+                
+                MatrixChainProblem prob = new MatrixChainProblem(id, sizes);
+                prob.setSubTypeId(subTypeId);
+                
+                log.debug("MatrixChainProblem retrieved successfully id={}, subTypeId={}", id, subTypeId);
+                return prob;
+            }
+            else {
+                log.warn("MatrixChainProblem not found id={}, subTypeId={}", id, subTypeId);
+                throw new NonRecoverableException("Inconsistent DB MatrixChainProblem: " + id);
+            }
+        } catch (SQLException e) {
+            log.error("SQLException retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId, e);
             throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
         } finally {
             close(stmt); // Don't close the connection, retrieve(courseId) will

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -186,33 +186,38 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
             close(stmt); // Don't close the connection, retrieve(courseId) will
         }
     }
-    
+
     /**
-     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given subTypeId.
-     * 
+     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given
+     * subTypeId.
+     *
      * @param id the id of the returned Matrix Chain problem
      * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table
      * @param conn an open connection to the DB, which isn't closed.
      * @return a MatrixChainProblem with the given id and subTypeId
      * @throws NonRecoverableException possible see getCause()
      */
-    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn) throws NonRecoverableException {
+    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn)
+            throws NonRecoverableException {
         log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
         final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ?";
-        
+
         PreparedStatement stmt = null;
-        
+
         try {
-            stmt = conn.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            stmt =
+                    conn.prepareStatement(
+                            sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
             stmt.setInt(1, subTypeId);
-            
+
             ResultSet rs = stmt.executeQuery();
-            
-            // Get the number of rows returned, then add each width and height to a numRows by 2 array for MatrixChainProblem
-            if (rs.last()){
+
+            // Get the number of rows returned, then add each width and height to a numRows by 2
+            // array for MatrixChainProblem
+            if (rs.last()) {
                 int numRows = rs.getRow();
                 log.debug("Number of Matrices={}", numRows);
-                
+
                 int[][] sizes = new int[numRows][2];
                 rs.beforeFirst();
                 int i = 0;
@@ -223,19 +228,25 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 }
                 log.debug("Matrix Sizes Array={}", Arrays.toString(sizes));
                 for (int[] size : sizes) log.debug("Size={}", Arrays.toString(size));
-                
+
                 MatrixChainProblem prob = new MatrixChainProblem(id, sizes);
                 prob.setSubTypeId(subTypeId);
-                
-                log.debug("MatrixChainProblem retrieved successfully id={}, subTypeId={}", id, subTypeId);
+
+                log.debug(
+                        "MatrixChainProblem retrieved successfully id={}, subTypeId={}",
+                        id,
+                        subTypeId);
                 return prob;
-            }
-            else {
+            } else {
                 log.warn("MatrixChainProblem not found id={}, subTypeId={}", id, subTypeId);
                 throw new NonRecoverableException("Inconsistent DB MatrixChainProblem: " + id);
             }
         } catch (SQLException e) {
-            log.error("SQLException retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId, e);
+            log.error(
+                    "SQLException retrieving MatrixChainProblem id={}, subTypeId={}",
+                    id,
+                    subTypeId,
+                    e);
             throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
         } finally {
             close(stmt); // Don't close the connection, retrieve(courseId) will

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -208,7 +208,7 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
         try {
             stmt =
                     conn.prepareStatement(
-                            sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+                            sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
             stmt.setInt(1, subTypeId);
 
             ResultSet rs = stmt.executeQuery();
@@ -227,7 +227,6 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                     sizes[i][1] = rs.getInt(3);
                     i++;
                 }
-                log.debug("Matrix Sizes Array={}", Arrays.toString(sizes));
                 for (int[] size : sizes) log.debug("Size={}", Arrays.toString(size));
 
                 MatrixChainProblem prob = new MatrixChainProblem(id, sizes);
@@ -240,7 +239,11 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 return prob;
             } else {
                 log.warn("MatrixChainProblem not found id={}, subTypeId={}", id, subTypeId);
-                throw new NonRecoverableException("Inconsistent DB MatrixChainProblem: " + id);
+                throw new NonRecoverableException(
+                        "Inconsistent DB MatrixChainProblem: id="
+                                + id
+                                + ", subTypeId="
+                                + subTypeId);
             }
         } catch (SQLException e) {
             log.error(

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -200,7 +200,8 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
     private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn)
             throws NonRecoverableException {
         log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
-        final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ? ORDER BY SizeId";
+        final String sql =
+                "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ? ORDER BY SizeId";
 
         PreparedStatement stmt = null;
 

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -185,33 +185,38 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
             close(stmt); // Don't close the connection, retrieve(courseId) will
         }
     }
-    
+
     /**
-     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given subTypeId.
-     * 
+     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given
+     * subTypeId.
+     *
      * @param id the id of the returned Matrix Chain problem
      * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table
      * @param conn an open connection to the DB, which isn't closed.
      * @return a MatrixChainProblem with the given id and subTypeId
      * @throws NonRecoverableException possible see getCause()
      */
-    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn) throws NonRecoverableException {
+    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn)
+            throws NonRecoverableException {
         log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
         final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ?";
-        
+
         PreparedStatement stmt = null;
-        
+
         try {
-            stmt = conn.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            stmt =
+                    conn.prepareStatement(
+                            sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
             stmt.setInt(1, subTypeId);
-            
+
             ResultSet rs = stmt.executeQuery();
-            
-            // Get the number of rows returned, then add each width and height to a numRows by 2 array for MatrixChainProblem
-            if (rs.last()){
+
+            // Get the number of rows returned, then add each width and height to a numRows by 2
+            // array for MatrixChainProblem
+            if (rs.last()) {
                 int numRows = rs.getRow();
                 log.debug("Number of Matrices={}", numRows);
-                
+
                 int[][] sizes = new int[numRows][2];
                 rs.beforeFirst();
                 int i = 0;
@@ -222,19 +227,25 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 }
                 log.debug("Matrix Sizes Array={}", Arrays.toString(sizes));
                 for (int[] size : sizes) log.debug("Size={}", Arrays.toString(size));
-                
+
                 MatrixChainProblem prob = new MatrixChainProblem(id, sizes);
                 prob.setSubTypeId(subTypeId);
-                
-                log.debug("MatrixChainProblem retrieved successfully id={}, subTypeId={}", id, subTypeId);
+
+                log.debug(
+                        "MatrixChainProblem retrieved successfully id={}, subTypeId={}",
+                        id,
+                        subTypeId);
                 return prob;
-            }
-            else {
+            } else {
                 log.warn("MatrixChainProblem not found id={}, subTypeId={}", id, subTypeId);
                 throw new NonRecoverableException("Inconsistent DB MatrixChainProblem: " + id);
             }
         } catch (SQLException e) {
-            log.error("SQLException retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId, e);
+            log.error(
+                    "SQLException retrieving MatrixChainProblem id={}, subTypeId={}",
+                    id,
+                    subTypeId,
+                    e);
             throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
         } finally {
             close(stmt); // Don't close the connection, retrieve(courseId) will

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -17,6 +17,9 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+
+import javax.sql.rowset.serial.SerialArray;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.MatrixChainProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.svc.ProblemSvc;
@@ -130,8 +134,9 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 return retrieveLCSProblem(id, subTypeId, conn);
 
             case MATRIX_CHAIN:
-                log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
-                return null;
+                // TODO: Implement retrieving Matrix Chain problem from the database
+                //log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
+                return retrieveMatrixChainProblem(id, subTypeId, conn);
 
             case KNAPSACK_0_1:
                 log.warn("KNAPSACK_0_1 retrieval not implemented for id={}", id);
@@ -179,6 +184,61 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
             }
         } catch (SQLException e) {
             log.error("SQLException retrieving LCSProblem id={}, subTypeId={}", id, subTypeId, e);
+            throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
+        } finally {
+            close(stmt); // Don't close the connection, retrieve(courseId) will
+        }
+    }
+    
+    /**
+     * 
+     * 
+     * @param id the id of the returned Matrix Chain problem
+     * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table
+     * @param conn an open connection to the DB, which isn't closed.
+     * @return a MatrixChainProblem with the given id and subTypeId
+     * @throws NonRecoverableException possible see getCause()
+     */
+    private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn) throws NonRecoverableException {
+        log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
+        final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ?";
+        
+        PreparedStatement stmt = null;
+        
+        try {
+            stmt = conn.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_UPDATABLE);
+            stmt.setInt(1, subTypeId);
+            
+            ResultSet rs = stmt.executeQuery();
+            
+            // Get the number of rows returned, then add each width and height to a numRows by 2 array for MatrixChainProblem
+            if (rs.last()){
+                int numRows = rs.getRow();
+                log.debug("Number of Matrices={}", numRows);
+                
+                int[][] sizes = new int[numRows][2];
+                rs.beforeFirst();
+                int i = 0;
+                while (rs.next()) {
+                    sizes[i][0] = rs.getInt(2);
+                    sizes[i][1] = rs.getInt(3);
+                    i++;
+                }
+                log.debug("Matrix Sizes Array={}", Arrays.toString(sizes));
+                for (int[] size : sizes) log.debug("Size={}", Arrays.toString(size));
+                
+                MatrixChainProblem prob = new MatrixChainProblem(id, sizes);
+                prob.setSubTypeId(subTypeId);
+                
+                log.debug("MatrixChainProblem retrieved successfully id={}, subTypeId={}", id, subTypeId);
+                return prob;
+            }
+            else {
+                log.warn("MatrixChainProblem not found id={}, subTypeId={}", id, subTypeId);
+                throw new NonRecoverableException("Inconsistent DB MatrixChainProblem: " + id);
+            }
+        } catch (SQLException e) {
+            log.error("SQLException retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId, e);
             throw new NonRecoverableException("ProblemDAO-ERR-2 " + e.toString(), e);
         } finally {
             close(stmt); // Don't close the connection, retrieve(courseId) will

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -19,8 +19,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-import javax.sql.rowset.serial.SerialArray;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,8 +133,6 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 return retrieveLCSProblem(id, subTypeId, conn);
 
             case MATRIX_CHAIN:
-                // TODO: Implement retrieving Matrix Chain problem from the database
-                //log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
                 return retrieveMatrixChainProblem(id, subTypeId, conn);
 
             case KNAPSACK_0_1:
@@ -192,7 +188,7 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
     }
     
     /**
-     * 
+     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given subTypeId.
      * 
      * @param id the id of the returned Matrix Chain problem
      * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -19,8 +19,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-import javax.sql.rowset.serial.SerialArray;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,8 +132,6 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
                 return retrieveLCSProblem(id, subTypeId, conn);
 
             case MATRIX_CHAIN:
-                // TODO: Implement retrieving Matrix Chain problem from the database
-                //log.warn("MATRIX_CHAIN retrieval not implemented for id={}", id);
                 return retrieveMatrixChainProblem(id, subTypeId, conn);
 
             case KNAPSACK_0_1:
@@ -191,7 +187,7 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
     }
     
     /**
-     * 
+     * Load and return a MatrixChainProblem from MatrixChainProblem table in the DB using the given subTypeId.
      * 
      * @param id the id of the returned Matrix Chain problem
      * @param subTypeId the id of the specific Matrix Chain problem in the MatrixChainProblem table

--- a/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/ProblemDAO.java
@@ -200,7 +200,7 @@ public class ProblemDAO extends MySqlDAO implements ProblemSvc {
     private MatrixChainProblem retrieveMatrixChainProblem(int id, int subTypeId, Connection conn)
             throws NonRecoverableException {
         log.debug("Retrieving MatrixChainProblem id={}, subTypeId={}", id, subTypeId);
-        final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ?";
+        final String sql = "SELECT SizeId, Width, Height from MatrixSizes where ProblemId = ? ORDER BY SizeId";
 
         PreparedStatement stmt = null;
 

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -170,7 +170,7 @@ public class MatrixChainProblem extends Problem {
     @Override
     public void reset() {
         log.debug(
-                "Reset requested: state {} -> PRE; histories cleared (exec={}, mHist={}, sHist={}, btStack={})",
+                "Reset requested: state {} -> PRE; histories cleared (exec={}, lHist={}, sHist={}, btStack={})",
                 executionState,
                 executionHistory.size(),
                 lHistory.size(),
@@ -220,7 +220,7 @@ public class MatrixChainProblem extends Problem {
                 "<html><pre>            cost = l[i][k] + l[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>"); // Line 7
         codeStatements.add(
                 "<html><pre>            if cost < l[i][j]: l[i][j] = cost</pre></html>"); // Line 8
-        codeStatements.add("<html><pre>return m</pre></html>"); // Line 9
+        codeStatements.add("<html><pre>return l</pre></html>"); // Line 9
     }
 
     @Override
@@ -261,7 +261,7 @@ public class MatrixChainProblem extends Problem {
         lHistory.push(new int[] {i, i, l[i][i]});
         l[i][i] = 0;
 
-        log.debug("executeLine1: set m[{}][{}]=0; n={}, i={}", i, i, n, i);
+        log.debug("executeLine1: set l[{}][{}]=0; n={}, i={}", i, i, n, i);
 
         if (i + 1 == n) {
             variables.put("c", 1);
@@ -338,7 +338,7 @@ public class MatrixChainProblem extends Problem {
         nextLineNumber = 6;
 
         log.debug(
-                "executeLine5: init m[{}][{}]=INF; k=i -> {}; nextLineNumber={}",
+                "executeLine5: init l[{}][{}]=INF; k=i -> {}; nextLineNumber={}",
                 i,
                 j,
                 i,
@@ -400,7 +400,7 @@ public class MatrixChainProblem extends Problem {
             s[i][j] = kVal;
 
             log.debug(
-                    "executeLine8: improved m[{}][{}]: {} -> {}; set s[{}][{}]={}",
+                    "executeLine8: improved l[{}][{}]: {} -> {}; set s[{}][{}]={}",
                     i,
                     j,
                     prev,
@@ -553,7 +553,7 @@ public class MatrixChainProblem extends Problem {
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 
-            log.debug("undoLine1: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
+            log.debug("undoLine1: restore l[{}][{}] -> {}", change[0], change[1], change[2]);
         }
 
         int i = (int) variables.get("i") - 1;
@@ -586,7 +586,7 @@ public class MatrixChainProblem extends Problem {
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 
-            log.debug("undoLine5: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
+            log.debug("undoLine5: restore l[{}][{}] -> {}", change[0], change[1], change[2]);
         }
     }
 
@@ -608,7 +608,7 @@ public class MatrixChainProblem extends Problem {
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 
-            log.debug("undoLine8: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
+            log.debug("undoLine8: restore l[{}][{}] -> {}", change[0], change[1], change[2]);
         }
 
         if (!sHistory.isEmpty()) {

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -85,9 +85,9 @@ public class MatrixChainProblem extends Problem {
         variables.put("k", 0);
         variables.put("d", d);
         /* used "l" for table variable to be consistent with LCSProblem
-           and because this previously using "m" caused issues in 
-           SubproblemTableView since it expected n=rows m=columns l=table */
-        variables.put("l", new int[n + 1][m + 1]); 
+        and because this previously using "m" caused issues in
+        SubproblemTableView since it expected n=rows m=columns l=table */
+        variables.put("l", new int[n + 1][m + 1]);
         variables.put("s", new int[n + 1][m + 1]);
         variables.put("b", new int[n + 1][m + 1]);
         bTable = (int[][]) variables.get("b");
@@ -217,7 +217,8 @@ public class MatrixChainProblem extends Problem {
         codeStatements.add("<html><pre>        for k = i to j-1</pre></html>"); // Line 6
         codeStatements.add(
                 "<html><pre>            cost = m[i][k] + m[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>"); // Line 7
-        codeStatements.add("<html><pre>            if cost < m[i][j]: m[i][j] = cost</pre></html>"); // Line 8
+        codeStatements.add(
+                "<html><pre>            if cost < m[i][j]: m[i][j] = cost</pre></html>"); // Line 8
         codeStatements.add("<html><pre>return m</pre></html>"); // Line 9
     }
 

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -70,7 +70,7 @@ public class MatrixChainProblem extends Problem {
     public MatrixChainProblem(int id, int[][] sizes) {
         super(id);
 
-        int n = sizes.length; // Number of rows (i.e. number of matricies)
+        int n = sizes.length; // Number of rows (i.e. number of matrices)
         int m = n; // Number of columns (equal to rows)
         ArrayList<Integer> d = new ArrayList<>();
 
@@ -116,6 +116,7 @@ public class MatrixChainProblem extends Problem {
                 sizes[0][1]);
 
         loadCodeStatements();
+        loadBacktrackingCodeStatements();
     }
 
     @Override

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -46,8 +46,8 @@ public class MatrixChainProblem extends Problem {
     // Current execution state
     private EXECUTION_STATE executionState;
 
-    // Stack to record changes to m[i][j]
-    private final Stack<int[]> mHistory = new Stack<>();
+    // Stack to record changes to l[i][j]
+    private final Stack<int[]> lHistory = new Stack<>();
 
     // For storing split table changes
     private final Stack<int[]> sHistory = new Stack<>();
@@ -173,7 +173,7 @@ public class MatrixChainProblem extends Problem {
                 "Reset requested: state {} -> PRE; histories cleared (exec={}, mHist={}, sHist={}, btStack={})",
                 executionState,
                 executionHistory.size(),
-                mHistory.size(),
+                lHistory.size(),
                 sHistory.size(),
                 btStack.size());
 
@@ -181,7 +181,7 @@ public class MatrixChainProblem extends Problem {
         nextLineNumber = 0;
 
         executionHistory.clear();
-        mHistory.clear();
+        lHistory.clear();
         sHistory.clear();
         btStack.clear();
         currentParens = "";
@@ -190,9 +190,10 @@ public class MatrixChainProblem extends Problem {
         int[][] s = (int[][]) variables.get("s");
         int[][] b = (int[][]) variables.get("b");
         int n = (int) variables.get("n");
+        int m = (int) variables.get("m");
 
         for (int i = 0; i <= n; i++)
-            for (int j = 0; j <= n; j++) {
+            for (int j = 0; j <= m; j++) {
                 l[i][j] = -1;
                 s[i][j] = -1;
                 b[i][j] = UNVISITED;
@@ -209,16 +210,16 @@ public class MatrixChainProblem extends Problem {
     @Override
     protected void loadCodeStatements() {
         codeStatements.add("<html><pre>for i = 0 to n-1</pre></html>"); // Line 0
-        codeStatements.add("<html><pre>    m[i][i] = 0</pre></html>"); // Line 1
+        codeStatements.add("<html><pre>    l[i][i] = 0</pre></html>"); // Line 1
         codeStatements.add("<html><pre>for c = 1 to n-1</pre></html>"); // Line 2
         codeStatements.add("<html><pre>    for i = 0 to n - c</pre></html>"); // Line 3
         codeStatements.add("<html><pre>        j = i + c</pre></html>"); // Line 4
-        codeStatements.add("<html><pre>        m[i][j] = ∞</pre></html>"); // Line 5
+        codeStatements.add("<html><pre>        l[i][j] = ∞</pre></html>"); // Line 5
         codeStatements.add("<html><pre>        for k = i to j-1</pre></html>"); // Line 6
         codeStatements.add(
-                "<html><pre>            cost = m[i][k] + m[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>"); // Line 7
+                "<html><pre>            cost = l[i][k] + l[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>"); // Line 7
         codeStatements.add(
-                "<html><pre>            if cost < m[i][j]: m[i][j] = cost</pre></html>"); // Line 8
+                "<html><pre>            if cost < l[i][j]: l[i][j] = cost</pre></html>"); // Line 8
         codeStatements.add("<html><pre>return m</pre></html>"); // Line 9
     }
 
@@ -257,7 +258,7 @@ public class MatrixChainProblem extends Problem {
         int n = (int) variables.get("n");
         int[][] l = (int[][]) variables.get("l");
 
-        mHistory.push(new int[] {i, i, l[i][i]});
+        lHistory.push(new int[] {i, i, l[i][i]});
         l[i][i] = 0;
 
         log.debug("executeLine1: set m[{}][{}]=0; n={}, i={}", i, i, n, i);
@@ -330,7 +331,7 @@ public class MatrixChainProblem extends Problem {
         int j = (int) variables.get("j");
         int[][] l = (int[][]) variables.get("l");
 
-        mHistory.push(new int[] {i, j, l[i][j]});
+        lHistory.push(new int[] {i, j, l[i][j]});
         l[i][j] = Integer.MAX_VALUE;
         variables.put("k", i);
 
@@ -389,7 +390,7 @@ public class MatrixChainProblem extends Problem {
         if (cost < l[i][j]) {
             int prev = l[i][j];
 
-            mHistory.push(new int[] {i, j, prev});
+            lHistory.push(new int[] {i, j, prev});
             l[i][j] = cost;
 
             int[][] s = (int[][]) variables.get("s");
@@ -547,8 +548,8 @@ public class MatrixChainProblem extends Problem {
     }
 
     public void undoLine1() {
-        if (!mHistory.isEmpty()) {
-            int[] change = mHistory.pop();
+        if (!lHistory.isEmpty()) {
+            int[] change = lHistory.pop();
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 
@@ -580,8 +581,8 @@ public class MatrixChainProblem extends Problem {
     }
 
     public void undoLine5() {
-        if (!mHistory.isEmpty()) {
-            int[] change = mHistory.pop();
+        if (!lHistory.isEmpty()) {
+            int[] change = lHistory.pop();
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 
@@ -602,8 +603,8 @@ public class MatrixChainProblem extends Problem {
     }
 
     public void undoLine8() {
-        if (!mHistory.isEmpty()) {
-            int[] change = mHistory.pop();
+        if (!lHistory.isEmpty()) {
+            int[] change = lHistory.pop();
             int[][] l = (int[][]) variables.get("l");
             l[change[0]][change[1]] = change[2];
 

--- a/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
+++ b/src/main/java/edu/regis/dptu/model/MatrixChainProblem.java
@@ -70,41 +70,47 @@ public class MatrixChainProblem extends Problem {
     public MatrixChainProblem(int id, int[][] sizes) {
         super(id);
 
-        int n = sizes.length;
+        int n = sizes.length; // Number of rows (i.e. number of matricies)
+        int m = n; // Number of columns (equal to rows)
         ArrayList<Integer> d = new ArrayList<>();
 
         d.add(sizes[0][0]);
         for (int[] size : sizes) d.add(size[1]);
 
         variables.put("n", n);
+        variables.put("m", m);
         variables.put("c", 1);
         variables.put("i", 0);
         variables.put("j", 0);
         variables.put("k", 0);
         variables.put("d", d);
-        variables.put("m", new int[n][n]);
-        variables.put("s", new int[n][n]);
-        variables.put("b", new int[n][n]);
+        /* used "l" for table variable to be consistent with LCSProblem
+           and because this previously using "m" caused issues in 
+           SubproblemTableView since it expected n=rows m=columns l=table */
+        variables.put("l", new int[n + 1][m + 1]); 
+        variables.put("s", new int[n + 1][m + 1]);
+        variables.put("b", new int[n + 1][m + 1]);
         bTable = (int[][]) variables.get("b");
 
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
         int[][] s = (int[][]) variables.get("s");
         int[][] b = (int[][]) variables.get("b");
 
-        for (int i = 0; i < n; i++)
-            for (int j = 0; j < n; j++) {
-                m[i][j] = -1;
+        for (int i = 0; i <= n; i++)
+            for (int j = 0; j <= m; j++) {
+                l[i][j] = -1;
                 s[i][j] = -1;
                 b[i][j] = UNVISITED;
             }
 
-        tableVariable = "m";
+        tableVariable = "l";
         executionState = EXECUTION_STATE.PRE;
 
         log.debug(
-                "MatrixChainProblem created: id={}, n={}, d.size={}, sizes[0]={}x{}",
+                "MatrixChainProblem created: id={}, n={}, m={}, d.size={}, sizes[0]={}x{}",
                 id,
                 n,
+                m,
                 d.size(),
                 sizes[0][0],
                 sizes[0][1]);
@@ -179,14 +185,14 @@ public class MatrixChainProblem extends Problem {
         btStack.clear();
         currentParens = "";
 
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
         int[][] s = (int[][]) variables.get("s");
         int[][] b = (int[][]) variables.get("b");
         int n = (int) variables.get("n");
 
-        for (int i = 0; i < n; i++)
-            for (int j = 0; j < n; j++) {
-                m[i][j] = -1;
+        for (int i = 0; i <= n; i++)
+            for (int j = 0; j <= n; j++) {
+                l[i][j] = -1;
                 s[i][j] = -1;
                 b[i][j] = UNVISITED;
             }
@@ -201,17 +207,17 @@ public class MatrixChainProblem extends Problem {
 
     @Override
     protected void loadCodeStatements() {
-        codeStatements.add("<html><pre>for i = 0 to n-1</pre></html>");
-        codeStatements.add("<html><pre>    m[i][i] = 0</pre></html>");
-        codeStatements.add("<html><pre>for c = 1 to n-1</pre></html>");
-        codeStatements.add("<html><pre>    for i = 0 to n - c</pre></html>");
-        codeStatements.add("<html><pre>        j = i + c</pre></html>");
-        codeStatements.add("<html><pre>        m[i][j] = ∞</pre></html>");
-        codeStatements.add("<html><pre>        for k = i to j-1</pre></html>");
+        codeStatements.add("<html><pre>for i = 0 to n-1</pre></html>"); // Line 0
+        codeStatements.add("<html><pre>    m[i][i] = 0</pre></html>"); // Line 1
+        codeStatements.add("<html><pre>for c = 1 to n-1</pre></html>"); // Line 2
+        codeStatements.add("<html><pre>    for i = 0 to n - c</pre></html>"); // Line 3
+        codeStatements.add("<html><pre>        j = i + c</pre></html>"); // Line 4
+        codeStatements.add("<html><pre>        m[i][j] = ∞</pre></html>"); // Line 5
+        codeStatements.add("<html><pre>        for k = i to j-1</pre></html>"); // Line 6
         codeStatements.add(
-                "<html><pre>            cost = m[i][k] + m[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>");
-        codeStatements.add("<html><pre>            if cost < m[i][j]: m[i][j] = cost</pre></html>");
-        codeStatements.add("<html><pre>return m</pre></html>");
+                "<html><pre>            cost = m[i][k] + m[k+1][j] + d[i]d[k+1]d[j+1]</pre></html>"); // Line 7
+        codeStatements.add("<html><pre>            if cost < m[i][j]: m[i][j] = cost</pre></html>"); // Line 8
+        codeStatements.add("<html><pre>return m</pre></html>"); // Line 9
     }
 
     @Override
@@ -247,10 +253,10 @@ public class MatrixChainProblem extends Problem {
     public void executeLine1() {
         int i = (int) variables.get("i");
         int n = (int) variables.get("n");
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
 
-        mHistory.push(new int[] {i, i, m[i][i]});
-        m[i][i] = 0;
+        mHistory.push(new int[] {i, i, l[i][i]});
+        l[i][i] = 0;
 
         log.debug("executeLine1: set m[{}][{}]=0; n={}, i={}", i, i, n, i);
 
@@ -320,10 +326,10 @@ public class MatrixChainProblem extends Problem {
     public void executeLine5() {
         int i = (int) variables.get("i");
         int j = (int) variables.get("j");
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
 
-        mHistory.push(new int[] {i, j, m[i][j]});
-        m[i][j] = Integer.MAX_VALUE;
+        mHistory.push(new int[] {i, j, l[i][j]});
+        l[i][j] = Integer.MAX_VALUE;
         variables.put("k", i);
 
         nextLineNumber = 6;
@@ -358,13 +364,13 @@ public class MatrixChainProblem extends Problem {
 
     @SuppressWarnings("unchecked")
     public void executeLine7() {
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
         int i = (int) variables.get("i");
         int j = (int) variables.get("j");
         int k = (int) variables.get("k");
         ArrayList<Integer> d = (ArrayList<Integer>) variables.get("d");
 
-        int cost = m[i][k] + m[k + 1][j] + d.get(i) * d.get(k + 1) * d.get(j + 1);
+        int cost = l[i][k] + l[k + 1][j] + d.get(i) * d.get(k + 1) * d.get(j + 1);
 
         variables.put("cost", cost);
         nextLineNumber = 8;
@@ -376,13 +382,13 @@ public class MatrixChainProblem extends Problem {
         int cost = (int) variables.get("cost");
         int i = (int) variables.get("i");
         int j = (int) variables.get("j");
-        int[][] m = (int[][]) variables.get("m");
+        int[][] l = (int[][]) variables.get("l");
 
-        if (cost < m[i][j]) {
-            int prev = m[i][j];
+        if (cost < l[i][j]) {
+            int prev = l[i][j];
 
             mHistory.push(new int[] {i, j, prev});
-            m[i][j] = cost;
+            l[i][j] = cost;
 
             int[][] s = (int[][]) variables.get("s");
             int kVal = (int) variables.get("k");
@@ -541,8 +547,8 @@ public class MatrixChainProblem extends Problem {
     public void undoLine1() {
         if (!mHistory.isEmpty()) {
             int[] change = mHistory.pop();
-            int[][] m = (int[][]) variables.get("m");
-            m[change[0]][change[1]] = change[2];
+            int[][] l = (int[][]) variables.get("l");
+            l[change[0]][change[1]] = change[2];
 
             log.debug("undoLine1: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
         }
@@ -574,8 +580,8 @@ public class MatrixChainProblem extends Problem {
     public void undoLine5() {
         if (!mHistory.isEmpty()) {
             int[] change = mHistory.pop();
-            int[][] m = (int[][]) variables.get("m");
-            m[change[0]][change[1]] = change[2];
+            int[][] l = (int[][]) variables.get("l");
+            l[change[0]][change[1]] = change[2];
 
             log.debug("undoLine5: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
         }
@@ -596,8 +602,8 @@ public class MatrixChainProblem extends Problem {
     public void undoLine8() {
         if (!mHistory.isEmpty()) {
             int[] change = mHistory.pop();
-            int[][] m = (int[][]) variables.get("m");
-            m[change[0]][change[1]] = change[2];
+            int[][] l = (int[][]) variables.get("l");
+            l[change[0]][change[1]] = change[2];
 
             log.debug("undoLine8: restore m[{}][{}] -> {}", change[0], change[1], change[2]);
         }
@@ -663,8 +669,7 @@ public class MatrixChainProblem extends Problem {
     }
 
     public EXECUTION_STATE getExecutionState() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'getExecutionState'");
+        return executionState;
     }
 
     public void prettyPrint() {

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -88,6 +88,8 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             this.model.addProblemListener(this);
             // When the Problem changes, we should updateStrings() to match
             ProblemKind pKind = model.getType();
+            ArrayList<String> rowHeaders = new ArrayList<>();
+            ArrayList<String> colHeaders = new ArrayList<>();
             switch (pKind) {
                 case MATRIX_CHAIN:
                     int[][] tableVariable =
@@ -97,19 +99,23 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                     int rows = tableVariable.length;
                     int cols = tableVariable[0].length;
                     log.debug("Updating Matrix Chain Table with (rows={}, cols={})", rows, cols);
-                    String Ms1 = "";
-                    String Ms2 = "";
-                    for (int i = 0; i < rows - 1; i++) Ms1 += String.valueOf(i);
-                    for (int i = 0; i < rows - 1; i++) Ms2 += String.valueOf(i);
-                    updateStrings(Ms1, Ms2);
+                    for (int i = 0; i < rows - 1; i++) rowHeaders.add(String.valueOf(i));
+                    for (int i = 0; i < cols - 1; i++) colHeaders.add(String.valueOf(i));
+                    updateStrings(rowHeaders, colHeaders);
                     break;
                 case KNAPSACK_0_1:
                     // TODO
                     break;
                 default: // i.e. LCS_PROBLEM
-                    String s1 = ((LCSProblem) model).getX();
-                    String s2 = ((LCSProblem) model).getY();
-                    updateStrings(s1, s2);
+                    String rowStr = ((LCSProblem) model).getX();
+                    String colStr = ((LCSProblem) model).getY();
+                    for (int i = 0; i < rowStr.length(); i++) {
+                        rowHeaders.add(Character.toUpperCase(rowStr.charAt(i)) + " (" + i + ")");
+                    }
+                    for (int i = 0; i < colStr.length(); i++) {
+                        colHeaders.add("<html><center>" + Character.toUpperCase(colStr.charAt(i)) + "<br>(" + i + ")</center></html>");
+                    }
+                    updateStrings(rowHeaders, colHeaders);
             }
             TableColumnModel columnModel = table.getColumnModel();
             columnModel.getColumn(0).setPreferredWidth(150);
@@ -267,38 +273,17 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     }
 
     /**
-     * Constructs the table's column header labels based on input characters.
+     * Constructs the table's column header labels based on input strings.
      *
-     * @param string String whose characters become column labels
+     * @param strings ArrayList of Strings that become column labels
      */
-    private void buildColumnHeaders(String string) {
+    private void buildColumnHeaders(ArrayList<String> strings) {
         ProblemKind pKind = model.getType();
         List<String> headers = new ArrayList<String>();
+        
         headers.add("table"); // Top-left corner label
-        switch (pKind) {
-            case LCS_PROBLEM:
-                headers.add("-1"); // Base case column
-                for (int i = 0; i < string.length(); i++) {
-                    // HTML formatting to center label and index
-                    headers.add(
-                            "<html><center>"
-                                    + string.charAt(i)
-                                    + "<br>("
-                                    + i
-                                    + ")</center></html>");
-                }
-                break;
-            case MATRIX_CHAIN:
-                // Matrix Chain doesn't use "-1" labels or multiline header labels
-                for (int i = 0; i < string.length(); i++) {
-                    // HTML formatting to center label
-                    headers.add("<html><center>" + string.charAt(i) + "</center></html>");
-                }
-                break;
-            case KNAPSACK_0_1:
-                // TODO
-                break;
-        }
+        if (pKind == ProblemKind.LCS_PROBLEM) headers.add("-1"); // Base case column
+        headers.addAll(strings);
 
         columnHeaders = headers.toArray(new String[headers.size()]);
     }
@@ -306,23 +291,16 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     /**
      * Builds the initial table data array with row labels and empty/default cells.
      *
-     * @param string String whose characters become row labels
+     * @param strings ArrayList of Strings that become row labels
      */
-    private void buildTableData(String string) {
+    private void buildTableData(ArrayList<String> strings) {
         ProblemKind pKind = model.getType();
         List<Object[]> rows = new ArrayList<>();
         List<String> rowHeaders = new ArrayList<String>();
 
-        // Matrix Chain doesn't use "-1" labels
-        // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is
-        // complete
-        if (pKind == ProblemKind.LCS_PROBLEM) {
-            rowHeaders.add("-1"); // Base case row label
-        }
+        if (pKind == ProblemKind.LCS_PROBLEM) rowHeaders.add("-1"); // Base case row label
+        rowHeaders.addAll(strings);
 
-        for (int i = 0; i < string.length(); i++) {
-            rowHeaders.add(String.valueOf(string.charAt(i)));
-        }
         if (columnHeaders == null) {
             tableData = new Object[0][0];
             return;
@@ -330,16 +308,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         // Create each row's data array
         for (int i = 0; i < rowHeaders.size(); i++) {
             Object[] toadd = new Object[columnHeaders.length];
-            if (i > 0) {
-                // Format row label with index
-                toadd[0] = rowHeaders.get(i);
-                // Only add index in parenthesis for LCS Problem
-                // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is
-                // complete
-                if (pKind == ProblemKind.LCS_PROBLEM) toadd[0] = toadd[0] + "  (" + (i - 1) + ")";
-            } else {
-                toadd[0] = rowHeaders.get(i);
-            }
+            toadd[0] = rowHeaders.get(i);
             rows.add(toadd);
         }
         tableData = rows.toArray(new Object[0][]);
@@ -468,18 +437,15 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     }
 
     /**
-     * Rebuilds table headers and data when input strings change. Dynamically reapplies renderers
+     * Rebuilds table headers and data when input headers change. Dynamically reapplies renderers
      * and refreshes the view.
-     *
-     * @param string1 The new first input String (x-axis labels)
-     * @param string2 The new second input String (y-axis labels)
+     * 
+     * @param rowHeaders ArrayList of row headers
+     * @param colHeaders ArrayList of column headers
      */
-    public void updateStrings(String string1, String string2) {
-        string1 = string1.toUpperCase();
-        string2 = string2.toUpperCase();
-
-        buildColumnHeaders(string2);
-        buildTableData(string1);
+    public void updateStrings(ArrayList<String> rowHeaders, ArrayList<String> colHeaders) {
+        buildColumnHeaders(colHeaders);
+        buildTableData(rowHeaders);
 
         // Replace model with new data
         table.setModel(new DefaultTableModel(tableData, columnHeaders));

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -113,7 +113,12 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                         rowHeaders.add(Character.toUpperCase(rowStr.charAt(i)) + " (" + i + ")");
                     }
                     for (int i = 0; i < colStr.length(); i++) {
-                        colHeaders.add("<html><center>" + Character.toUpperCase(colStr.charAt(i)) + "<br>(" + i + ")</center></html>");
+                        colHeaders.add(
+                                "<html><center>"
+                                        + Character.toUpperCase(colStr.charAt(i))
+                                        + "<br>("
+                                        + i
+                                        + ")</center></html>");
                     }
                     updateStrings(rowHeaders, colHeaders);
             }
@@ -280,7 +285,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     private void buildColumnHeaders(ArrayList<String> strings) {
         ProblemKind pKind = model.getType();
         List<String> headers = new ArrayList<String>();
-        
+
         headers.add("table"); // Top-left corner label
         if (pKind == ProblemKind.LCS_PROBLEM) headers.add("-1"); // Base case column
         headers.addAll(strings);
@@ -439,7 +444,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
     /**
      * Rebuilds table headers and data when input headers change. Dynamically reapplies renderers
      * and refreshes the view.
-     * 
+     *
      * @param rowHeaders ArrayList of row headers
      * @param colHeaders ArrayList of column headers
      */

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -96,8 +96,8 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                     log.debug("Updating Matrix Chain Table with (rows={}, cols={})", rows, cols);
                     String Ms1 = "";
                     String Ms2 = "";
-                    for (int i = 0; i < rows; i++) Ms1 += String.valueOf(i);
-                    for (int i = 0; i < rows; i++) Ms2 += String.valueOf(i);
+                    for (int i = 0; i < rows - 1; i++) Ms1 += String.valueOf(i);
+                    for (int i = 0; i < rows - 1; i++) Ms2 += String.valueOf(i);
                     updateStrings(Ms1, Ms2);
                     break;
                 case KNAPSACK_0_1:
@@ -164,7 +164,6 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         table =
                 new JTable() {
                     @Override
-                    // TODO: Figure out why this gets called for too many rows for MatrixChain, but the right amount for LCS
                     public Component prepareRenderer(TableCellRenderer renderer, int row, int col) {
                         Component component = super.prepareRenderer(renderer, row, col);
                         if (col < 1) {
@@ -270,13 +269,29 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
      * @param string String whose characters become column labels
      */
     private void buildColumnHeaders(String string) {
+        ProblemKind pKind = model.getType();
         List<String> headers = new ArrayList<String>();
         headers.add("table"); // Top-left corner label
-        headers.add("-1"); // Base case column
-        for (int i = 0; i < string.length(); i++) {
-            // HTML formatting to center label and index
-            headers.add("<html><center>" + string.charAt(i) + "<br>(" + i + ")</center></html>");
+        switch (pKind) {
+            case LCS_PROBLEM:
+                headers.add("-1"); // Base case column
+                for (int i = 0; i < string.length(); i++) {
+                    // HTML formatting to center label and index
+                    headers.add("<html><center>" + string.charAt(i) + "<br>(" + i + ")</center></html>");
+                }
+                break;
+            case MATRIX_CHAIN:
+                // Matrix Chain doesn't use "-1" labels or multiline header labels
+                for (int i = 0; i < string.length(); i++) {
+                    // HTML formatting to center label
+                    headers.add("<html><center>" + string.charAt(i) + "</center></html>");
+                }
+                break;
+            case KNAPSACK_0_1:
+                // TODO
+                break;
         }
+        
         columnHeaders = headers.toArray(new String[headers.size()]);
     }
 
@@ -286,9 +301,16 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
      * @param string String whose characters become row labels
      */
     private void buildTableData(String string) {
+        ProblemKind pKind = model.getType();
         List<Object[]> rows = new ArrayList<>();
         List<String> rowHeaders = new ArrayList<String>();
-        rowHeaders.add("-1"); // Base case row label
+        
+        // Matrix Chain doesn't use "-1" labels
+        // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is complete
+        if (pKind == ProblemKind.LCS_PROBLEM) {
+            rowHeaders.add("-1"); // Base case row label
+        }
+        
         for (int i = 0; i < string.length(); i++) {
             rowHeaders.add(String.valueOf(string.charAt(i)));
         }
@@ -301,7 +323,10 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             Object[] toadd = new Object[columnHeaders.length];
             if (i > 0) {
                 // Format row label with index
-                toadd[0] = rowHeaders.get(i) + "  (" + (i - 1) + ")";
+                toadd[0] = rowHeaders.get(i);
+                // Only add index in parenthesis for LCS Problem
+                // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is complete
+                if (pKind == ProblemKind.LCS_PROBLEM) toadd[0] = toadd[0] + "  (" + (i - 1) + ")";
             } else {
                 toadd[0] = rowHeaders.get(i);
             }
@@ -328,6 +353,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 || model.getVariableObject("m") == null) {
             return;
         }
+        ProblemKind pKind = model.getType(); 
         Object tableObj = model.getVariableObject(model.getTableVariable());
         Object nObj = model.getVariableObject("n"); // Number of rows
         Object mObj = model.getVariableObject("m"); // Number of columns
@@ -342,6 +368,11 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         int n = (int) nObj;
         int m = (int) mObj;
         DefaultTableModel dtm = (DefaultTableModel) table.getModel();
+        // Since Matrix Chain doesn't use the extra "-1" rows and columns
+        if (pKind == ProblemKind.MATRIX_CHAIN) {
+            n--;
+            m--;
+        }
         // Ensure table has sufficient size
         if (dtm.getRowCount() < n + 1 || dtm.getColumnCount() < m + 2) {
             log.error("SubproblemTableView: Table dimensions too small.", (Throwable) null);

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.MatrixChainProblem;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.ProblemKind;
 import edu.regis.dptu.model.ProblemListener;
@@ -89,7 +90,15 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             ProblemKind pKind = model.getType();
             switch (pKind) {
                 case MATRIX_CHAIN:
-                    // TODO
+                    int[][] tableVariable = (int[][]) ((MatrixChainProblem) model).getVariableObject(model.getTableVariable());
+                    int rows = tableVariable.length;
+                    int cols = tableVariable[0].length;
+                    log.debug("Updating Matrix Chain Table with (rows={}, cols={})", rows, cols);
+                    String Ms1 = "";
+                    String Ms2 = "";
+                    for (int i = 0; i < rows; i++) Ms1 += String.valueOf(i);
+                    for (int i = 0; i < rows; i++) Ms2 += String.valueOf(i);
+                    updateStrings(Ms1, Ms2);
                     break;
                 case KNAPSACK_0_1:
                     // TODO
@@ -155,6 +164,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         table =
                 new JTable() {
                     @Override
+                    // TODO: Figure out why this gets called for too many rows for MatrixChain, but the right amount for LCS
                     public Component prepareRenderer(TableCellRenderer renderer, int row, int col) {
                         Component component = super.prepareRenderer(renderer, row, col);
                         if (col < 1) {
@@ -319,8 +329,8 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             return;
         }
         Object tableObj = model.getVariableObject(model.getTableVariable());
-        Object nObj = model.getVariableObject("n");
-        Object mObj = model.getVariableObject("m");
+        Object nObj = model.getVariableObject("n"); // Number of rows
+        Object mObj = model.getVariableObject("m"); // Number of columns
         // Type check for DP table and indices
         if (!(tableObj instanceof int[][])
                 || !(nObj instanceof Integer)

--- a/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
+++ b/src/main/java/edu/regis/dptu/view/SubproblemTableView.java
@@ -90,7 +90,10 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
             ProblemKind pKind = model.getType();
             switch (pKind) {
                 case MATRIX_CHAIN:
-                    int[][] tableVariable = (int[][]) ((MatrixChainProblem) model).getVariableObject(model.getTableVariable());
+                    int[][] tableVariable =
+                            (int[][])
+                                    ((MatrixChainProblem) model)
+                                            .getVariableObject(model.getTableVariable());
                     int rows = tableVariable.length;
                     int cols = tableVariable[0].length;
                     log.debug("Updating Matrix Chain Table with (rows={}, cols={})", rows, cols);
@@ -277,7 +280,12 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 headers.add("-1"); // Base case column
                 for (int i = 0; i < string.length(); i++) {
                     // HTML formatting to center label and index
-                    headers.add("<html><center>" + string.charAt(i) + "<br>(" + i + ")</center></html>");
+                    headers.add(
+                            "<html><center>"
+                                    + string.charAt(i)
+                                    + "<br>("
+                                    + i
+                                    + ")</center></html>");
                 }
                 break;
             case MATRIX_CHAIN:
@@ -291,7 +299,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 // TODO
                 break;
         }
-        
+
         columnHeaders = headers.toArray(new String[headers.size()]);
     }
 
@@ -304,13 +312,14 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
         ProblemKind pKind = model.getType();
         List<Object[]> rows = new ArrayList<>();
         List<String> rowHeaders = new ArrayList<String>();
-        
+
         // Matrix Chain doesn't use "-1" labels
-        // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is complete
+        // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is
+        // complete
         if (pKind == ProblemKind.LCS_PROBLEM) {
             rowHeaders.add("-1"); // Base case row label
         }
-        
+
         for (int i = 0; i < string.length(); i++) {
             rowHeaders.add(String.valueOf(string.charAt(i)));
         }
@@ -325,7 +334,8 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 // Format row label with index
                 toadd[0] = rowHeaders.get(i);
                 // Only add index in parenthesis for LCS Problem
-                // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is complete
+                // TODO: Add header formatting logic if needed for 0-1 Knapsack once that problem is
+                // complete
                 if (pKind == ProblemKind.LCS_PROBLEM) toadd[0] = toadd[0] + "  (" + (i - 1) + ")";
             } else {
                 toadd[0] = rowHeaders.get(i);
@@ -353,7 +363,7 @@ public class SubproblemTableView extends GPanel implements ProblemListener {
                 || model.getVariableObject("m") == null) {
             return;
         }
-        ProblemKind pKind = model.getType(); 
+        ProblemKind pKind = model.getType();
         Object tableObj = model.getVariableObject(model.getTableVariable());
         Object nObj = model.getVariableObject("n"); // Number of rows
         Object mObj = model.getVariableObject("m"); // Number of columns

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
   <Properties>
     <Property name="APP_NAME">dptu</Property>
     <Property name="LOG_DIR">${sys:user.home}/.${APP_NAME}/logs</Property>
-    <Property name="ROOT_LEVEL">${sys:LOG_LEVEL:-INFO}</Property>
+    <Property name="ROOT_LEVEL">${sys:LOG_LEVEL:-DEBUG}</Property>
   </Properties>
 
   <Appenders>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
   <Properties>
     <Property name="APP_NAME">dptu</Property>
     <Property name="LOG_DIR">${sys:user.home}/.${APP_NAME}/logs</Property>
-    <Property name="ROOT_LEVEL">${sys:LOG_LEVEL:-DEBUG}</Property>
+    <Property name="ROOT_LEVEL">${sys:LOG_LEVEL:-INFO}</Property>
   </Properties>
 
   <Appenders>

--- a/src/test/java/edu/regis/dptu/test/MatrixChainProblemCoverageTest.java
+++ b/src/test/java/edu/regis/dptu/test/MatrixChainProblemCoverageTest.java
@@ -51,7 +51,7 @@ public class MatrixChainProblemCoverageTest {
         int[][] sizes = {{3, 4}, {4, 5}};
         MatrixChainProblem problem = new MatrixChainProblem(sizes);
 
-        assertThrows(UnsupportedOperationException.class, problem::getExecutionState);
+        //assertThrows(UnsupportedOperationException.class, problem::getExecutionState);
         assertThrows(UnsupportedOperationException.class, problem::prettyPrint);
     }
 

--- a/src/test/java/edu/regis/dptu/test/MatrixChainProblemCoverageTest.java
+++ b/src/test/java/edu/regis/dptu/test/MatrixChainProblemCoverageTest.java
@@ -51,7 +51,6 @@ public class MatrixChainProblemCoverageTest {
         int[][] sizes = {{3, 4}, {4, 5}};
         MatrixChainProblem problem = new MatrixChainProblem(sizes);
 
-        //assertThrows(UnsupportedOperationException.class, problem::getExecutionState);
         assertThrows(UnsupportedOperationException.class, problem::prettyPrint);
     }
 


### PR DESCRIPTION
The code for `MatrixChainProblem` was already complete enough that all of the tests for it passed, but it was not implemented into a problem view for See One. 

This PR adds `MatrixChainProblem` functionality to the mySQL database along with an example problem from the slides `CS324Day19_DP.pptx` on the WorldClass, documentation in `DATABASE_SCHEMA.md`, and a function in `ProblemDao` to retrieve it from the database.

I also updated `MatrixChainProblem` itself to change the names of the main table variable since `SubproblemTableView` looks for it to be named `l` (lowercase "L"), and looks for the number of rows and columns to be `n` and `m` respectively. Also updated the table size to fit what `SubproblemTableView` wanted.

Finally I added support for `MatrixChainProblem` to `SubproblemTableView` using a wide variety of hack-and-slash changes that I should make better but not at midnight.

There's still a few issues with the See One problem, mainly that the Subsequence section isn't updated and contains whatever was last in it for a previous `LCSProblem`, and I'm not actually 100% sure that the `MatrixChainProblem` is done correctly since there's one part where it's different from the WorldClass slides, and the slides don't show the backtrack part.