### PR TITLE
DPTU-172 Task Completion Persistence

### DIFF
--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -54,8 +54,9 @@ public class SplashFrame extends JFrame {
     /** Allowed consecutive illegal passwords before the user is locked out. */
     public static final int MAX_SIGNIN_ATTEMPTS = 3;
 
-    /** The tutoring session for the currently signed-in user gotten during login*/
-    private static TutoringSession SIGNED_IN_SESSION = null;;
+    /** The tutoring session for the currently signed-in user gotten during login */
+    private static TutoringSession SIGNED_IN_SESSION = null;
+    ;
 
     /** The single instance of this frame. */
     private static final SplashFrame SINGLETON;

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -56,7 +56,6 @@ public class SplashFrame extends JFrame {
 
     /** The tutoring session for the currently signed-in user gotten during login */
     private static TutoringSession SIGNED_IN_SESSION = null;
-    ;
 
     /** The single instance of this frame. */
     private static final SplashFrame SINGLETON;

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -105,16 +105,23 @@ public class SplashFrame extends JFrame {
         return SIGNED_IN_SESSION;
     }
 
+    private TutoringSession requireSignedInSession() {
+        if (SIGNED_IN_SESSION == null) {
+            throw new IllegalStateException("No user is currently signed in.");
+        }
+        return SIGNED_IN_SESSION;
+    }
+
     public int getSessionId() {
-        return SIGNED_IN_SESSION.getId();
+        return requireSignedInSession().getId();
     }
 
     public String getSecurityToken() {
-        return SIGNED_IN_SESSION.getSecurityToken();
+        return requireSignedInSession().getSecurityToken();
     }
 
     public String getUserId() {
-        return SIGNED_IN_SESSION.getUserId();
+        return requireSignedInSession().getUserId();
     }
 
     /** All student info should reside here. */

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -54,6 +54,9 @@ public class SplashFrame extends JFrame {
     /** Allowed consecutive illegal passwords before the user is locked out. */
     public static final int MAX_SIGNIN_ATTEMPTS = 3;
 
+    /** The tutoring session for the currently signed-in user gotten during login*/
+    private static TutoringSession SIGNED_IN_SESSION = null;;
+
     /** The single instance of this frame. */
     private static final SplashFrame SINGLETON;
 
@@ -91,6 +94,26 @@ public class SplashFrame extends JFrame {
         boolean reset = isFirstLogin;
         isFirstLogin = false;
         return reset;
+    }
+
+    public void setSignedInSession(TutoringSession session) {
+        SIGNED_IN_SESSION = session;
+    }
+
+    public TutoringSession getSignedInSession() {
+        return SIGNED_IN_SESSION;
+    }
+
+    public int getSessionId() {
+        return SIGNED_IN_SESSION.getId();
+    }
+
+    public String getSecurityToken() {
+        return SIGNED_IN_SESSION.getSecurityToken();
+    }
+
+    public String getUserId() {
+        return SIGNED_IN_SESSION.getUserId();
     }
 
     /** All student info should reside here. */

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -126,8 +126,13 @@ public class TutoringSessionView extends GPanel {
                             ClientRequest req = new ClientRequest(ServerRequestType.COMPLETED_TASK);
                             req.setUserId(userId);
                             req.setSecurityToken(token);
+                            req.setSessionId(String.valueOf(model.getId()));
                             req.setData(String.valueOf(taskId));
-                            log.info("Sending COMPLETED_TASK userId={} taskId{}", userId, taskId);
+                            log.info(
+                                "Sending COMPLETED_TASK userId={} sessionId={} tokenPresent={} taskId={}",
+                                userId,
+                                model.getId(),
+                                token != null && !token.isBlank(), taskId);
 
                             TutorReply reply = SvcFacade.instance().tutorRequest(req);
                             log.info(

--- a/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
+++ b/src/main/java/edu/regis/dptu/view/TutoringSessionView.java
@@ -129,10 +129,11 @@ public class TutoringSessionView extends GPanel {
                             req.setSessionId(String.valueOf(model.getId()));
                             req.setData(String.valueOf(taskId));
                             log.info(
-                                "Sending COMPLETED_TASK userId={} sessionId={} tokenPresent={} taskId={}",
-                                userId,
-                                model.getId(),
-                                token != null && !token.isBlank(), taskId);
+                                    "Sending COMPLETED_TASK userId={} sessionId={} tokenPresent={} taskId={}",
+                                    userId,
+                                    model.getId(),
+                                    token != null && !token.isBlank(),
+                                    taskId);
 
                             TutorReply reply = SvcFacade.instance().tutorRequest(req);
                             log.info(

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -86,6 +86,25 @@ public class SeeOneAction extends DpTuGuiAction {
 
             TutoringSession ts = new TutoringSession(account, problem);
             ts.setMode(Mode.SEE_ONE);
+            TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
+            log.debug(
+                "SeeOneAction retrieved signedInSession: userId={} sessionId={} token={}",
+                signedInSession != null ? signedInSession.getUserId() : null,
+                signedInSession != null ? signedInSession.getId() : null,
+                signedInSession != null ? signedInSession.getSecurityToken() : null);
+
+            if (signedInSession != null) {
+                ts.setId(signedInSession.getId());
+                ts.setSecurityToken(signedInSession.getSecurityToken());
+                ts.setUserId(signedInSession.getUserId());
+                log.info("Initialized SEE_ONE session with existing sessionId={} and securityToken={} and userId={}", 
+                    ts.getId(), 
+                    ts.getSecurityToken(),
+                    ts.getUserId());
+            } else {
+                log.warn( "No signed-in session found in SplashFrame; " + 
+                    "SEE_ONE session has no authorization context (sessionId or securityToken)");
+            }
 
             int taskId = problem.getTaskId();
             if (taskId < 0) {

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -88,22 +88,24 @@ public class SeeOneAction extends DpTuGuiAction {
             ts.setMode(Mode.SEE_ONE);
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             log.debug(
-                "SeeOneAction retrieved signedInSession: userId={} sessionId={} token={}",
-                signedInSession != null ? signedInSession.getUserId() : null,
-                signedInSession != null ? signedInSession.getId() : null,
-                signedInSession != null ? signedInSession.getSecurityToken() : null);
+                    "SeeOneAction retrieved signedInSession: userId={} sessionId={} token={}",
+                    signedInSession != null ? signedInSession.getUserId() : null,
+                    signedInSession != null ? signedInSession.getId() : null,
+                    signedInSession != null ? signedInSession.getSecurityToken() : null);
 
             if (signedInSession != null) {
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
-                log.info("Initialized SEE_ONE session with existing sessionId={} and securityToken={} and userId={}", 
-                    ts.getId(), 
-                    ts.getSecurityToken(),
-                    ts.getUserId());
+                log.info(
+                        "Initialized SEE_ONE session with existing sessionId={} and securityToken={} and userId={}",
+                        ts.getId(),
+                        ts.getSecurityToken(),
+                        ts.getUserId());
             } else {
-                log.warn( "No signed-in session found in SplashFrame; " + 
-                    "SEE_ONE session has no authorization context (sessionId or securityToken)");
+                log.warn(
+                        "No signed-in session found in SplashFrame; "
+                                + "SEE_ONE session has no authorization context (sessionId or securityToken)");
             }
 
             int taskId = problem.getTaskId();

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -88,19 +88,19 @@ public class SeeOneAction extends DpTuGuiAction {
             ts.setMode(Mode.SEE_ONE);
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             log.debug(
-                    "SeeOneAction retrieved signedInSession: userId={} sessionId={} token={}",
+                    "SeeOneAction retrieved signedInSession: userId={} sessionId={} tokenPresent={}",
                     signedInSession != null ? signedInSession.getUserId() : null,
                     signedInSession != null ? signedInSession.getId() : null,
-                    signedInSession != null ? signedInSession.getSecurityToken() : null);
+                    signedInSession != null && signedInSession.getSecurityToken() != null);
 
             if (signedInSession != null) {
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
                 log.info(
-                        "Initialized SEE_ONE session with existing sessionId={} and securityToken={} and userId={}",
+                        "Initialized SEE_ONE session with existing sessionId={} tokenPresent={} and userId={}",
                         ts.getId(),
-                        ts.getSecurityToken(),
+                        ts.getSecurityToken() != null,
                         ts.getUserId());
             } else {
                 log.warn(

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -80,7 +80,8 @@ public class SignInAction extends DpTuGuiAction {
         switch (reply.getStatus()) {
             case "Authenticated":
                 try {
-                    JsonObject sessionJson = JsonParser.parseString(reply.getData()).getAsJsonObject();
+                    JsonObject sessionJson =
+                            JsonParser.parseString(reply.getData()).getAsJsonObject();
                     int sessionId = sessionJson.get("id").getAsInt();
                     String securityToken = sessionJson.get("securityToken").getAsString();
                     TutoringSession signedInSession = new TutoringSession(user.getUserId());
@@ -88,8 +89,11 @@ public class SignInAction extends DpTuGuiAction {
                     signedInSession.setSecurityToken(securityToken);
                     SplashFrame.instance().setSignedInSession(signedInSession);
                     signedInSession.setUserId(frame.getUserId());
-                    log.info("sessionId={} securityToken={} stored in SplashFrame for userId={}", sessionId, securityToken, signedInSession.getUserId());
-
+                    log.info(
+                            "sessionId={} securityToken={} stored in SplashFrame for userId={}",
+                            sessionId,
+                            securityToken,
+                            signedInSession.getUserId());
 
                     AccountDAO accDao = new AccountDAO();
                     Account studentAccount = accDao.retrieve(user.getUserId());

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -83,10 +83,13 @@ public class SignInAction extends DpTuGuiAction {
                     JsonObject sessionJson =
                             JsonParser.parseString(reply.getData()).getAsJsonObject();
                     if (!sessionJson.has("id") || !sessionJson.has("securityToken")) {
-                        log.error("SIGN_IN reply missing required session fields: {}", reply.getData());
-                        SplashFrame.instance().showError(
-                            ResourceMgr.instance().string("dialog.title.error"),
-                            "Login succeeded but session data was incomplete");
+                        log.error(
+                                "SIGN_IN reply missing required session fields: {}",
+                                reply.getData());
+                        SplashFrame.instance()
+                                .showError(
+                                        ResourceMgr.instance().string("dialog.title.error"),
+                                        "Login succeeded but session data was incomplete");
                         return;
                     }
                     int sessionId = sessionJson.get("id").getAsInt();

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -90,9 +90,9 @@ public class SignInAction extends DpTuGuiAction {
                     SplashFrame.instance().setSignedInSession(signedInSession);
                     signedInSession.setUserId(frame.getUserId());
                     log.info(
-                            "sessionId={} securityToken={} stored in SplashFrame for userId={}",
+                            "sessionId={} securityTokenPresent={} stored in SplashFrame for userId={}",
                             sessionId,
-                            securityToken,
+                            securityToken != null && !securityToken.isEmpty(),
                             signedInSession.getUserId());
 
                     AccountDAO accDao = new AccountDAO();

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -21,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import edu.regis.dptu.dao.AccountDAO;
 import edu.regis.dptu.dao.StudentModelDAO;
@@ -28,6 +30,7 @@ import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.Student;
+import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.model.User;
 import edu.regis.dptu.model.aol.StudentModel;
 import edu.regis.dptu.svc.ClientRequest;
@@ -77,6 +80,17 @@ public class SignInAction extends DpTuGuiAction {
         switch (reply.getStatus()) {
             case "Authenticated":
                 try {
+                    JsonObject sessionJson = JsonParser.parseString(reply.getData()).getAsJsonObject();
+                    int sessionId = sessionJson.get("id").getAsInt();
+                    String securityToken = sessionJson.get("securityToken").getAsString();
+                    TutoringSession signedInSession = new TutoringSession(user.getUserId());
+                    signedInSession.setId(sessionId);
+                    signedInSession.setSecurityToken(securityToken);
+                    SplashFrame.instance().setSignedInSession(signedInSession);
+                    signedInSession.setUserId(frame.getUserId());
+                    log.info("sessionId={} securityToken={} stored in SplashFrame for userId={}", sessionId, securityToken, signedInSession.getUserId());
+
+
                     AccountDAO accDao = new AccountDAO();
                     Account studentAccount = accDao.retrieve(user.getUserId());
                     StudentModelDAO smDao = new StudentModelDAO();

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -82,6 +82,13 @@ public class SignInAction extends DpTuGuiAction {
                 try {
                     JsonObject sessionJson =
                             JsonParser.parseString(reply.getData()).getAsJsonObject();
+                    if (!sessionJson.has("id") || !sessionJson.has("securityToken")) {
+                        log.error("SIGN_IN reply missing required session fields: {}", reply.getData());
+                        SplashFrame.instance().showError(
+                            ResourceMgr.instance().string("dialog.title.error"),
+                            "Login succeeded but session data was incomplete");
+                        return;
+                    }
                     int sessionId = sessionJson.get("id").getAsInt();
                     String securityToken = sessionJson.get("securityToken").getAsString();
                     TutoringSession signedInSession = new TutoringSession(user.getUserId());


### PR DESCRIPTION
Task completion events are now successfully persisted to the database when a user finishes a problem in SEE_ONE mode.

This required these changes:
- Parsing session metadata from the SIGN_IN response
- Storing authenticated session context in SplashFrame for reuse across views
- Propogating session identity into newly created TutoringSession instances in SeeOneAction
- Fixing incorrect userId mappings

Note: The persistence is saved in the database, but currently the tutoring app doesn't do anything if a task is already completed. In a future PR, we need to write what happens when a user has already completed a task.