### PR TITLE
DPTU-159 Raise non-UI unit test coverage above 90%

### DIFF
--- a/src/main/java/edu/regis/dptu/util/ImgFactory.java
+++ b/src/main/java/edu/regis/dptu/util/ImgFactory.java
@@ -38,16 +38,20 @@ public class ImgFactory {
      *
      * @param fileName The file name of the image to load.
      * @param altText Alternative text for the ImageIcon.
-     * @return ImageIcon with the corresponding image, or null if not found.
+     * @return ImageIcon with the corresponding image, or an empty icon with the given alternative
+     *     text if the image is not found.
      */
     public static ImageIcon createIcon(String fileName, String altText) {
         BufferedImage img = createImage(fileName);
         if (img != null) {
             log.debug("Successfully created ImageIcon for file '{}'", fileName);
+            return new ImageIcon(img, altText);
         } else {
             log.warn("Failed to create ImageIcon for file '{}'", fileName);
+            ImageIcon icon = new ImageIcon();
+            icon.setDescription(altText);
+            return icon;
         }
-        return new ImageIcon(img, altText);
     }
 
     /**

--- a/src/test/java/edu/regis/dptu/test/CourseDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/CourseDAOTest.java
@@ -279,14 +279,19 @@ public class CourseDAOTest {
         ResultSet outcomesRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(anyString()))
-                .thenReturn(courseStmt)
-                .thenReturn(locationsStmt)
-                .thenReturn(unitsStmt)
-                .thenReturn(tasksStmt)
-                .thenReturn(stepsStmt)
-                .thenReturn(timeoutStmt)
-                .thenReturn(hintsStmt)
-                .thenReturn(outcomesStmt);
+                .thenAnswer(
+                        invocation -> {
+                            String sql = invocation.getArgument(0, String.class).toLowerCase();
+                            if (sql.contains("primarypedagogy")) return courseStmt;
+                            if (sql.contains("from exercisinglocation")) return locationsStmt;
+                            if (sql.contains("from unit")) return unitsStmt;
+                            if (sql.contains("from task")) return tasksStmt;
+                            if (sql.contains("from step")) return stepsStmt;
+                            if (sql.contains("from timeout")) return timeoutStmt;
+                            if (sql.contains("from hint")) return hintsStmt;
+                            if (sql.contains("knowledgecomponent")) return outcomesStmt;
+                            return courseStmt;
+                        });
 
         when(courseStmt.executeQuery()).thenReturn(courseRs);
         when(locationsStmt.executeQuery()).thenReturn(locationsRs);
@@ -384,10 +389,15 @@ public class CourseDAOTest {
         ResultSet tasksRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(anyString()))
-                .thenReturn(courseStmt)
-                .thenReturn(locationsStmt)
-                .thenReturn(unitsStmt)
-                .thenReturn(tasksStmt);
+                .thenAnswer(
+                        invocation -> {
+                            String sql = invocation.getArgument(0, String.class).toLowerCase();
+                            if (sql.contains("primarypedagogy")) return courseStmt;
+                            if (sql.contains("exercisinglocation")) return locationsStmt;
+                            if (sql.contains("from unit")) return unitsStmt;
+                            if (sql.contains("from task")) return tasksStmt;
+                            return courseStmt;
+                        });
 
         when(courseStmt.executeQuery()).thenReturn(courseRs);
         when(locationsStmt.executeQuery()).thenReturn(locationsRs);

--- a/src/test/java/edu/regis/dptu/test/CourseDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/CourseDAOTest.java
@@ -33,9 +33,12 @@ import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Course;
 import edu.regis.dptu.model.CourseDigest;
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Task;
 import edu.regis.dptu.model.TaskKind;
 import edu.regis.dptu.model.UnitDigest;
+import edu.regis.dptu.svc.ProblemSvc;
+import edu.regis.dptu.svc.ServiceFactory;
 
 /**
  * Unit test class for CourseDAO using mocked database connections
@@ -252,5 +255,174 @@ public class CourseDAOTest {
         assertThrows(
                 NonRecoverableException.class,
                 () -> dao.retrieveTask(TEST_COURSE_ID, TEST_TASK_ID, mockConnection));
+    }
+
+    /** Test full retrieve path that traverses units, tasks, steps, hints, and outcomes. */
+    @Test
+    public void testRetrieveFullCourseStructure() throws Exception {
+        PreparedStatement courseStmt = mock(PreparedStatement.class);
+        PreparedStatement locationsStmt = mock(PreparedStatement.class);
+        PreparedStatement unitsStmt = mock(PreparedStatement.class);
+        PreparedStatement tasksStmt = mock(PreparedStatement.class);
+        PreparedStatement stepsStmt = mock(PreparedStatement.class);
+        PreparedStatement timeoutStmt = mock(PreparedStatement.class);
+        PreparedStatement hintsStmt = mock(PreparedStatement.class);
+        PreparedStatement outcomesStmt = mock(PreparedStatement.class);
+
+        ResultSet courseRs = mock(ResultSet.class);
+        ResultSet locationsRs = mock(ResultSet.class);
+        ResultSet unitsRs = mock(ResultSet.class);
+        ResultSet tasksRs = mock(ResultSet.class);
+        ResultSet stepsRs = mock(ResultSet.class);
+        ResultSet timeoutRs = mock(ResultSet.class);
+        ResultSet hintsRs = mock(ResultSet.class);
+        ResultSet outcomesRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(anyString()))
+                .thenReturn(courseStmt)
+                .thenReturn(locationsStmt)
+                .thenReturn(unitsStmt)
+                .thenReturn(tasksStmt)
+                .thenReturn(stepsStmt)
+                .thenReturn(timeoutStmt)
+                .thenReturn(hintsStmt)
+                .thenReturn(outcomesStmt);
+
+        when(courseStmt.executeQuery()).thenReturn(courseRs);
+        when(locationsStmt.executeQuery()).thenReturn(locationsRs);
+        when(unitsStmt.executeQuery()).thenReturn(unitsRs);
+        when(tasksStmt.executeQuery()).thenReturn(tasksRs);
+        when(stepsStmt.executeQuery()).thenReturn(stepsRs);
+        when(timeoutStmt.executeQuery()).thenReturn(timeoutRs);
+        when(hintsStmt.executeQuery()).thenReturn(hintsRs);
+        when(outcomesStmt.executeQuery()).thenReturn(outcomesRs);
+
+        when(courseRs.next()).thenReturn(true);
+        when(courseRs.getString(1)).thenReturn("Dynamic Programming");
+        when(courseRs.getString(2)).thenReturn("FIXED_SEQUENCE");
+        when(courseRs.getString(3)).thenReturn("Course description");
+
+        when(locationsRs.next()).thenReturn(true).thenReturn(false);
+        when(locationsRs.getInt(1)).thenReturn(0);
+        when(locationsRs.getInt(2)).thenReturn(1);
+        when(locationsRs.getInt(3)).thenReturn(5);
+        when(locationsRs.getInt(4)).thenReturn(9);
+
+        when(unitsRs.next()).thenReturn(true).thenReturn(false);
+        when(unitsRs.getInt(1)).thenReturn(1);
+        when(unitsRs.getString(2)).thenReturn("Unit 1");
+        when(unitsRs.getString(3)).thenReturn("Unit description");
+        when(unitsRs.getInt(4)).thenReturn(0);
+        when(unitsRs.getString(5)).thenReturn("Fixed Sequence");
+
+        when(tasksRs.next()).thenReturn(true).thenReturn(false);
+        when(tasksRs.getInt(1)).thenReturn(5);
+        when(tasksRs.getString(2)).thenReturn("Task 1");
+        when(tasksRs.getString(3)).thenReturn("Task description");
+        when(tasksRs.getString(4)).thenReturn("PROBLEM");
+        when(tasksRs.getInt(5)).thenReturn(0);
+        when(tasksRs.getInt(6)).thenReturn(10);
+
+        when(stepsRs.next()).thenReturn(true).thenReturn(false);
+        when(stepsRs.getInt(1)).thenReturn(9);
+        when(stepsRs.getString(2)).thenReturn("Step title");
+        when(stepsRs.getString(3)).thenReturn("Step description");
+        when(stepsRs.getInt(4)).thenReturn(0);
+        when(stepsRs.getString(5)).thenReturn("INFO_MESSAGE");
+        when(stepsRs.getInt(7)).thenReturn(2);
+
+        when(timeoutRs.next()).thenReturn(true);
+        when(timeoutRs.getString(1)).thenReturn("SOFT");
+        when(timeoutRs.getInt(2)).thenReturn(15);
+        when(timeoutRs.getString(3)).thenReturn("WARN");
+        when(timeoutRs.getString(4)).thenReturn("Keep going");
+
+        when(hintsRs.next()).thenReturn(true).thenReturn(false);
+        when(hintsRs.getInt(1)).thenReturn(1);
+        when(hintsRs.getString(2)).thenReturn("Hint text");
+        when(hintsRs.getInt(3)).thenReturn(0);
+
+        when(outcomesRs.next()).thenReturn(true).thenReturn(false);
+        when(outcomesRs.getInt(1)).thenReturn(111);
+        when(outcomesRs.getString(2)).thenReturn("Outcome 1");
+        when(outcomesRs.getString(3)).thenReturn("Outcome description");
+        when(outcomesRs.getString(4)).thenReturn("Knowledge");
+        when(outcomesRs.getBoolean(5)).thenReturn(true);
+        when(outcomesRs.getString(6)).thenReturn("Fixed Sequence");
+        when(outcomesRs.getString(7)).thenReturn("0");
+        when(outcomesRs.getString(8)).thenReturn("Course");
+
+        ProblemSvc problemSvc = mock(ProblemSvc.class);
+        when(problemSvc.retrieve(10)).thenReturn(new LCSProblem(10, "AB", "AC"));
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findProblemSvc).thenReturn(problemSvc);
+
+            Course course = dao.retrieve(TEST_COURSE_ID);
+
+            assertNotNull(course);
+            assertEquals(TEST_COURSE_ID, course.getId());
+            assertEquals("Dynamic Programming", course.getTitle());
+            assertEquals(1, course.getUnits().size());
+            assertEquals(1, course.getOutcomes().size());
+            assertEquals(1, course.currentUnit().getTasks().size());
+            assertNotNull(course.currentUnit().getTasks().get(0).getProblem());
+        }
+    }
+
+    /** Test inconsistent DB branch when a PROBLEM task references a missing problem row. */
+    @Test
+    public void testRetrieveWithMissingProblemReferenceThrowsNonRecoverable() throws Exception {
+        PreparedStatement courseStmt = mock(PreparedStatement.class);
+        PreparedStatement locationsStmt = mock(PreparedStatement.class);
+        PreparedStatement unitsStmt = mock(PreparedStatement.class);
+        PreparedStatement tasksStmt = mock(PreparedStatement.class);
+
+        ResultSet courseRs = mock(ResultSet.class);
+        ResultSet locationsRs = mock(ResultSet.class);
+        ResultSet unitsRs = mock(ResultSet.class);
+        ResultSet tasksRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(anyString()))
+                .thenReturn(courseStmt)
+                .thenReturn(locationsStmt)
+                .thenReturn(unitsStmt)
+                .thenReturn(tasksStmt);
+
+        when(courseStmt.executeQuery()).thenReturn(courseRs);
+        when(locationsStmt.executeQuery()).thenReturn(locationsRs);
+        when(unitsStmt.executeQuery()).thenReturn(unitsRs);
+        when(tasksStmt.executeQuery()).thenReturn(tasksRs);
+
+        when(courseRs.next()).thenReturn(true);
+        when(courseRs.getString(1)).thenReturn("Course");
+        when(courseRs.getString(2)).thenReturn("FIXED_SEQUENCE");
+        when(courseRs.getString(3)).thenReturn("Course description");
+
+        when(locationsRs.next()).thenReturn(false);
+
+        when(unitsRs.next()).thenReturn(true).thenReturn(false);
+        when(unitsRs.getInt(1)).thenReturn(1);
+        when(unitsRs.getString(2)).thenReturn("Unit 1");
+        when(unitsRs.getString(3)).thenReturn("Unit description");
+        when(unitsRs.getInt(4)).thenReturn(0);
+        when(unitsRs.getString(5)).thenReturn("Fixed Sequence");
+
+        when(tasksRs.next()).thenReturn(true);
+        when(tasksRs.getInt(1)).thenReturn(5);
+        when(tasksRs.getString(2)).thenReturn("Task 1");
+        when(tasksRs.getString(3)).thenReturn("Task description");
+        when(tasksRs.getString(4)).thenReturn("PROBLEM");
+        when(tasksRs.getInt(5)).thenReturn(0);
+        when(tasksRs.getInt(6)).thenReturn(222);
+
+        ProblemSvc problemSvc = mock(ProblemSvc.class);
+        when(problemSvc.retrieve(222)).thenThrow(new ObjNotFoundException("missing problem"));
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findProblemSvc).thenReturn(problemSvc);
+
+            assertThrows(NonRecoverableException.class, () -> dao.retrieve(TEST_COURSE_ID));
+        }
     }
 }

--- a/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
@@ -41,7 +41,7 @@ public class DpTuServerConnectionTest {
     @Test
     public void dpTuConnectionReadsRequestAndWritesReply() throws Exception {
         String requestJson =
-            "{\"requestType\":\"REQUEST_HINT\",\"data\":\"{}\",\"userId\":\"student@regis.edu\",\"securityToken\":\"token-1\"}\n";
+                "{\"requestType\":\"REQUEST_HINT\",\"data\":\"{}\",\"userId\":\"student@regis.edu\",\"securityToken\":\"token-1\"}\n";
 
         ByteArrayInputStream in =
                 new ByteArrayInputStream(requestJson.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
@@ -19,13 +19,21 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.regis.dptu.model.Account;
+import edu.regis.dptu.model.aol.StudentModel;
+import edu.regis.dptu.svc.AccountSvc;
 import edu.regis.dptu.svc.DpTuServer;
+import edu.regis.dptu.svc.ServiceFactory;
+import edu.regis.dptu.svc.SessionSvc;
+import edu.regis.dptu.svc.StudentModelSvc;
 
 @SuppressWarnings("Logging")
 public class DpTuServerConnectionTest {
@@ -33,7 +41,7 @@ public class DpTuServerConnectionTest {
     @Test
     public void dpTuConnectionReadsRequestAndWritesReply() throws Exception {
         String requestJson =
-                "{\"requestType\":\"CREATE_ACCOUNT\",\"data\":\"{}\",\"userId\":\"\",\"securityToken\":\"\"}\n";
+            "{\"requestType\":\"REQUEST_HINT\",\"data\":\"{}\",\"userId\":\"student@regis.edu\",\"securityToken\":\"token-1\"}\n";
 
         ByteArrayInputStream in =
                 new ByteArrayInputStream(requestJson.getBytes(StandardCharsets.UTF_8));
@@ -43,16 +51,32 @@ public class DpTuServerConnectionTest {
         when(client.getInputStream()).thenReturn(in);
         when(client.getOutputStream()).thenReturn(out);
 
-        DpTuServer server = new DpTuServer();
-        Class<?> connClass = Class.forName("edu.regis.dptu.svc.DpTuServer$DpTuConnection");
-        Constructor<?> ctor = connClass.getDeclaredConstructor(DpTuServer.class, Socket.class);
-        ctor.setAccessible(true);
+        Account account = new Account("student@regis.edu", "pw");
+        SessionSvc sessionSvc = mock(SessionSvc.class);
+        AccountSvc accountSvc = mock(AccountSvc.class);
+        StudentModelSvc studentModelSvc = mock(StudentModelSvc.class);
+        StudentModel studentModel = new StudentModel(account.getUserId());
 
-        Runnable connection = (Runnable) ctor.newInstance(server, client);
-        connection.run();
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(sessionSvc);
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(accountSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(studentModelSvc);
+
+            when(sessionSvc.retrieveSecurityToken(account.getUserId())).thenReturn("token-1");
+            when(accountSvc.retrieve(account.getUserId())).thenReturn(account);
+            when(studentModelSvc.retrieve(account.getUserId())).thenReturn(studentModel);
+
+            DpTuServer server = new DpTuServer();
+            Class<?> connClass = Class.forName("edu.regis.dptu.svc.DpTuServer$DpTuConnection");
+            Constructor<?> ctor = connClass.getDeclaredConstructor(DpTuServer.class, Socket.class);
+            ctor.setAccessible(true);
+
+            Runnable connection = (Runnable) ctor.newInstance(server, client);
+            connection.run();
+        }
 
         String replyJson = out.toString(StandardCharsets.UTF_8);
-        assertTrue(replyJson.contains("status"));
+        assertTrue(replyJson.contains("\"status\":\"Hint\""));
         verify(client).close();
     }
 }

--- a/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuServerConnectionTest.java
@@ -1,0 +1,58 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Constructor;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.regis.dptu.svc.DpTuServer;
+
+@SuppressWarnings("Logging")
+public class DpTuServerConnectionTest {
+
+    @Test
+    public void dpTuConnectionReadsRequestAndWritesReply() throws Exception {
+        String requestJson =
+                "{\"requestType\":\"CREATE_ACCOUNT\",\"data\":\"{}\",\"userId\":\"\",\"securityToken\":\"\"}\n";
+
+        ByteArrayInputStream in =
+                new ByteArrayInputStream(requestJson.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        Socket client = mock(Socket.class);
+        when(client.getInputStream()).thenReturn(in);
+        when(client.getOutputStream()).thenReturn(out);
+
+        DpTuServer server = new DpTuServer();
+        Class<?> connClass = Class.forName("edu.regis.dptu.svc.DpTuServer$DpTuConnection");
+        Constructor<?> ctor = connClass.getDeclaredConstructor(DpTuServer.class, Socket.class);
+        ctor.setAccessible(true);
+
+        Runnable connection = (Runnable) ctor.newInstance(server, client);
+        connection.run();
+
+        String replyJson = out.toString(StandardCharsets.UTF_8);
+        assertTrue(replyJson.contains("status"));
+        verify(client).close();
+    }
+}

--- a/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
@@ -84,6 +84,8 @@ public class DpTuTutorTest {
             when(mockSessionSvc.retrieveSecurityToken(anyString())).thenReturn("db-token");
 
             ClientRequest req = new ClientRequest(ServerRequestType.REQUEST_HINT);
+            req.setUserId("");
+            req.setSecurityToken(null);
             req.setData("{}");
             // Empty securityToken does not match "db-token" → verifySession returns false → :ERR
 

--- a/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
@@ -76,16 +76,22 @@ public class DpTuTutorTest {
     }
 
     @Test
-    public void requestHintThroughRequestDispatcher() {
+    public void requestHintThroughRequestDispatcher() throws Exception {
         DpTuTutor tutor = new DpTuTutor();
 
-        ClientRequest req = new ClientRequest(ServerRequestType.REQUEST_HINT);
-        req.setData("{}");
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            when(mockSessionSvc.retrieveSecurityToken(anyString())).thenReturn("db-token");
 
-        TutorReply reply = tutor.request(req);
+            ClientRequest req = new ClientRequest(ServerRequestType.REQUEST_HINT);
+            req.setData("{}");
+            // Empty securityToken does not match "db-token" → verifySession returns false → :ERR
 
-        assertEquals(":ERR", reply.getStatus());
-        assertNotNull(reply.getData());
+            TutorReply reply = tutor.request(req);
+
+            assertEquals(":ERR", reply.getStatus());
+            assertNotNull(reply.getData());
+        }
     }
 
     @Test

--- a/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
+++ b/src/test/java/edu/regis/dptu/test/DpTuTutorTest.java
@@ -13,26 +13,67 @@
 package edu.regis.dptu.test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import com.google.gson.Gson;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import edu.regis.dptu.err.IllegalArgException;
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Account;
+import edu.regis.dptu.model.Course;
+import edu.regis.dptu.model.LCSProblem;
 import edu.regis.dptu.model.Step;
 import edu.regis.dptu.model.StepCompletion;
 import edu.regis.dptu.model.StepSubType;
 import edu.regis.dptu.model.Student;
+import edu.regis.dptu.model.Task;
+import edu.regis.dptu.model.TaskSelectionKind;
+import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.model.Unit;
+import edu.regis.dptu.model.aol.StudentModel;
+import edu.regis.dptu.svc.AccountSvc;
 import edu.regis.dptu.svc.ClientRequest;
+import edu.regis.dptu.svc.CompletedTaskSvc;
+import edu.regis.dptu.svc.CourseSvc;
 import edu.regis.dptu.svc.DpTuTutor;
 import edu.regis.dptu.svc.ServerRequestType;
+import edu.regis.dptu.svc.ServiceFactory;
+import edu.regis.dptu.svc.SessionSvc;
+import edu.regis.dptu.svc.StudentModelSvc;
 import edu.regis.dptu.svc.TutorReply;
 
 @SuppressWarnings("Logging")
 public class DpTuTutorTest {
     private static final Gson GSON = new Gson();
+    private AccountSvc mockAccountSvc;
+    private CourseSvc mockCourseSvc;
+    private SessionSvc mockSessionSvc;
+    private StudentModelSvc mockStudentModelSvc;
+    private CompletedTaskSvc mockCompletedTaskSvc;
+
+    @BeforeEach
+    public void setUpServices() {
+        mockAccountSvc = mock(AccountSvc.class);
+        mockCourseSvc = mock(CourseSvc.class);
+        mockSessionSvc = mock(SessionSvc.class);
+        mockStudentModelSvc = mock(StudentModelSvc.class);
+        mockCompletedTaskSvc = mock(CompletedTaskSvc.class);
+    }
 
     @Test
     public void requestHintThroughRequestDispatcher() {
@@ -100,6 +141,371 @@ public class DpTuTutorTest {
 
         assertEquals("Hint", reply.getStatus());
         assertEquals("This is a hint from the tutor.", reply.getData());
+    }
+
+    @Test
+    public void completedTaskThroughRequestDispatcherWithValidSessionReturnsOk() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+
+        Account account = new Account("student@regis.edu", "pass");
+        StudentModel studentModel = new StudentModel(account.getUserId());
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+            mockedFactory
+                    .when(ServiceFactory::findCompletedTaskSvc)
+                    .thenReturn(mockCompletedTaskSvc);
+
+            when(mockSessionSvc.retrieveSecurityToken(account.getUserId())).thenReturn("token-1");
+            when(mockAccountSvc.retrieve(account.getUserId())).thenReturn(account);
+            when(mockStudentModelSvc.retrieve(account.getUserId())).thenReturn(studentModel);
+
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_TASK);
+            request.setUserId(account.getUserId());
+            request.setSecurityToken("token-1");
+            request.setData("7");
+
+            TutorReply reply = tutor.request(request);
+
+            assertEquals(":OK", reply.getStatus());
+            assertTrue(reply.getData().contains("Completed taskId= 7"));
+            verify(mockCompletedTaskSvc).markCompleted(account.getUserId(), 7);
+        }
+    }
+
+    @Test
+    public void completedTaskThroughRequestDispatcherWithBadTokenReturnsError() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            when(mockSessionSvc.retrieveSecurityToken("student@regis.edu")).thenReturn("expected");
+
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_TASK);
+            request.setUserId("student@regis.edu");
+            request.setSecurityToken("wrong");
+            request.setData("7");
+
+            TutorReply reply = tutor.request(request);
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("Illegal Security Token"));
+        }
+    }
+
+    @Test
+    public void signInWithMatchingPasswordReturnsAuthenticated() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account requestAcct = new Account("student@regis.edu", "pw");
+        Account dbAcct = new Account("student@regis.edu", "pw");
+        StudentModel studentModel = new StudentModel(dbAcct.getUserId());
+        TutoringSession session = new TutoringSession(dbAcct.getUserId());
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+
+            when(mockAccountSvc.retrieve(dbAcct.getUserId())).thenReturn(dbAcct);
+            when(mockStudentModelSvc.retrieve(dbAcct.getUserId())).thenReturn(studentModel);
+            when(mockSessionSvc.retrieve(any(Student.class))).thenReturn(session);
+
+            TutorReply reply = tutor.signIn(GSON.toJson(requestAcct));
+
+            assertEquals("Authenticated", reply.getStatus());
+            assertNotNull(reply.getData());
+            assertTrue(reply.getData().contains(dbAcct.getUserId()));
+        }
+    }
+
+    @Test
+    public void signInWithUnknownUserReturnsUnknownUser() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account requestAcct = new Account("missing@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            when(mockAccountSvc.retrieve(anyString()))
+                    .thenThrow(new ObjNotFoundException("missing"));
+
+            TutorReply reply = tutor.signIn(GSON.toJson(requestAcct));
+
+            assertEquals("UnknownUser", reply.getStatus());
+        }
+    }
+
+    @Test
+    public void createAccountHappyPathReturnsCreated() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("new@regis.edu", "pw");
+
+        Course course = buildCourseForSessionCreation();
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+
+            when(mockCourseSvc.retrieve(1)).thenReturn(course);
+
+            TutorReply reply = tutor.createAccount(GSON.toJson(account));
+
+            assertEquals("Created", reply.getStatus());
+            verify(mockAccountSvc).create(any(Account.class));
+            verify(mockStudentModelSvc).create(any(Student.class));
+            verify(mockSessionSvc).create(any(TutoringSession.class));
+        }
+    }
+
+    @Test
+    public void createAccountWithDuplicateUserReturnsIllegalUserId() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("dupe@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            doThrow(new IllegalArgException("exists"))
+                    .when(mockAccountSvc)
+                    .create(any(Account.class));
+
+            TutorReply reply = tutor.createAccount(GSON.toJson(account));
+
+            assertEquals("IllegalUserId", reply.getStatus());
+        }
+    }
+
+    @Test
+    public void completedTaskWhenPersistenceFailsReturnsErrorReply() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        setStudent(tutor, new Student(new Account("unit@test.edu")));
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory
+                    .when(ServiceFactory::findCompletedTaskSvc)
+                    .thenReturn(mockCompletedTaskSvc);
+            doThrow(new NonRecoverableException("db down"))
+                    .when(mockCompletedTaskSvc)
+                    .markCompleted(anyString(), anyInt());
+
+            TutorReply reply = tutor.completedTask("99");
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("Failed to record completed task"));
+        }
+    }
+
+    @Test
+    public void requestWithMissingSessionReturnsError() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            when(mockSessionSvc.retrieveSecurityToken("student@regis.edu"))
+                    .thenThrow(new ObjNotFoundException("missing session"));
+
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_TASK);
+            request.setUserId("student@regis.edu");
+            request.setSecurityToken("token");
+            request.setData("5");
+
+            TutorReply reply = tutor.request(request);
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("No session exists for user"));
+        }
+    }
+
+    @Test
+    public void requestWithMissingStudentModelReturnsError() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("student@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+
+            when(mockSessionSvc.retrieveSecurityToken(account.getUserId())).thenReturn("token");
+            when(mockAccountSvc.retrieve(account.getUserId())).thenReturn(account);
+            when(mockStudentModelSvc.retrieve(account.getUserId()))
+                    .thenThrow(new ObjNotFoundException("missing model"));
+
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_TASK);
+            request.setUserId(account.getUserId());
+            request.setSecurityToken("token");
+            request.setData("3");
+
+            TutorReply reply = tutor.request(request);
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("Student model not found"));
+        }
+    }
+
+    @Test
+    public void signInWithInvalidPasswordReturnsInvalidPassword() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account requestAcct = new Account("student@regis.edu", "bad");
+        Account dbAcct = new Account("student@regis.edu", "expected");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            when(mockAccountSvc.retrieve(dbAcct.getUserId())).thenReturn(dbAcct);
+
+            TutorReply reply = tutor.signIn(GSON.toJson(requestAcct));
+
+            assertEquals("InvalidPassword", reply.getStatus());
+        }
+    }
+
+    @Test
+    public void signInWithMissingStudentModelReturnsErrorReply() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account requestAcct = new Account("student@regis.edu", "pw");
+        Account dbAcct = new Account("student@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+
+            when(mockAccountSvc.retrieve(dbAcct.getUserId())).thenReturn(dbAcct);
+            when(mockStudentModelSvc.retrieve(dbAcct.getUserId()))
+                    .thenThrow(new ObjNotFoundException("missing model"));
+
+            TutorReply reply = tutor.signIn(GSON.toJson(requestAcct));
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("Student model not found in sign in"));
+        }
+    }
+
+    @Test
+    public void signInWithServiceFailureReturnsDefaultErrorReply() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account requestAcct = new Account("student@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            when(mockAccountSvc.retrieve(anyString())).thenThrow(new NonRecoverableException("db"));
+
+            TutorReply reply = tutor.signIn(GSON.toJson(requestAcct));
+
+            assertEquals("ERR", reply.getStatus());
+        }
+    }
+
+    @Test
+    public void createAccountWithMissingCourseReturnsError() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("new@regis.edu", "pw");
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
+
+            when(mockCourseSvc.retrieve(1)).thenThrow(new ObjNotFoundException("missing course"));
+
+            TutorReply reply = tutor.createAccount(GSON.toJson(account));
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("Unknown course"));
+        }
+    }
+
+    @Test
+    public void requestWithSessionServiceFailureReturnsError() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+            when(mockSessionSvc.retrieveSecurityToken("student@regis.edu"))
+                    .thenThrow(new NonRecoverableException("token lookup failed"));
+
+            ClientRequest request = new ClientRequest(ServerRequestType.COMPLETED_TASK);
+            request.setUserId("student@regis.edu");
+            request.setSecurityToken("token");
+            request.setData("3");
+
+            TutorReply reply = tutor.request(request);
+
+            assertEquals(":ERR", reply.getStatus());
+            assertTrue(reply.getData().contains("NonRecoverableException"));
+        }
+    }
+
+    @Test
+    public void createAccountWithoutSequenceZeroUnitThrowsNonRecoverable() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("new2@regis.edu", "pw");
+
+        Course course = new Course(1);
+        course.setPrimaryPedagogy(TaskSelectionKind.FIXED_SEQUENCE);
+        course.setExercisingLocations(new ArrayList<>());
+
+        Unit unit = new Unit(2);
+        unit.setSequenceId(1);
+        course.addUnit(unit);
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+
+            when(mockCourseSvc.retrieve(1)).thenReturn(course);
+
+            assertThrows(
+                    NonRecoverableException.class, () -> tutor.createAccount(GSON.toJson(account)));
+        }
+    }
+
+    @Test
+    public void createAccountWithoutFirstTaskThrowsNonRecoverable() throws Exception {
+        DpTuTutor tutor = new DpTuTutor();
+        Account account = new Account("new3@regis.edu", "pw");
+
+        Course course = new Course(1);
+        course.setPrimaryPedagogy(TaskSelectionKind.FIXED_SEQUENCE);
+        course.setExercisingLocations(new ArrayList<>());
+
+        Unit unit = new Unit(1);
+        unit.setSequenceId(0);
+        unit.setTasks(new ArrayList<>());
+        course.addUnit(unit);
+
+        try (MockedStatic<ServiceFactory> mockedFactory = mockStatic(ServiceFactory.class)) {
+            mockedFactory.when(ServiceFactory::findAccountSvc).thenReturn(mockAccountSvc);
+            mockedFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
+            mockedFactory.when(ServiceFactory::findStudentModelSvc).thenReturn(mockStudentModelSvc);
+            mockedFactory.when(ServiceFactory::findSessionSvc).thenReturn(mockSessionSvc);
+
+            when(mockCourseSvc.retrieve(1)).thenReturn(course);
+
+            assertThrows(
+                    NonRecoverableException.class, () -> tutor.createAccount(GSON.toJson(account)));
+        }
+    }
+
+    private static Course buildCourseForSessionCreation() {
+        Course course = new Course(1);
+        course.setPrimaryPedagogy(TaskSelectionKind.FIXED_SEQUENCE);
+        course.setExercisingLocations(new ArrayList<>());
+
+        Unit unit = new Unit(1);
+        unit.setSequenceId(0);
+
+        Task task = new Task(1);
+        task.setSequenceIndex(0);
+        task.setProblem(new LCSProblem(101, "AB", "AC"));
+        task.addStep(new Step(1, 0, StepSubType.INFO_MESSAGE));
+
+        unit.addTask(task);
+        course.addUnit(unit);
+
+        return course;
     }
 
     private static String stepCompletionJson(StepSubType subType) {

--- a/src/test/java/edu/regis/dptu/test/ModelTest.java
+++ b/src/test/java/edu/regis/dptu/test/ModelTest.java
@@ -1,0 +1,59 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.regis.dptu.model.Model;
+
+@SuppressWarnings("Logging")
+public class ModelTest {
+
+    @Test
+    public void modelSupportsIdentityAndValueSemantics() {
+        StubModel defaultModel = new StubModel();
+        StubModel modelA = new StubModel(7);
+        StubModel modelB = new StubModel(7);
+        StubModel modelC = new StubModel(9);
+
+        assertEquals(Model.DEFAULT_ID, defaultModel.getId());
+        assertEquals(7, modelA.getId());
+
+        modelA.setId(8);
+        assertEquals(8, modelA.getId());
+
+        assertTrue(modelA.equals(modelA));
+        assertFalse(modelA.equals(null));
+        assertFalse(modelA.equals("not-model"));
+        assertTrue(modelB.equals(new StubModel(7)));
+        assertFalse(modelB.equals(modelC));
+
+        assertEquals(7, modelA.hashCode());
+        assertNotEquals("", modelA.toString());
+    }
+
+    private static class StubModel extends Model {
+        StubModel() {
+            super();
+        }
+
+        StubModel(int id) {
+            super(id);
+        }
+    }
+}

--- a/src/test/java/edu/regis/dptu/test/ModelTest.java
+++ b/src/test/java/edu/regis/dptu/test/ModelTest.java
@@ -43,7 +43,7 @@ public class ModelTest {
         assertTrue(modelB.equals(new StubModel(7)));
         assertFalse(modelB.equals(modelC));
 
-        assertEquals(7, modelA.hashCode());
+        assertEquals(new StubModel(8).hashCode(), modelA.hashCode());
         assertNotEquals("", modelA.toString());
     }
 

--- a/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
@@ -127,9 +127,14 @@ public class ProblemCoreTest {
         problem.finishOnNextStep = true;
         problem.step(3);
 
-        long deadline = System.currentTimeMillis() + 1500;
+        long deadline = System.currentTimeMillis() + 6000;
         while (problem.executeCount == 0 && System.currentTimeMillis() < deadline) {
-            Thread.yield();
+            try {
+                Thread.sleep(25);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
         }
 
         assertTrue(problem.executeCount >= 1);

--- a/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
@@ -1,0 +1,219 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
+import edu.regis.dptu.model.ProblemListener;
+
+@SuppressWarnings("Logging")
+public class ProblemCoreTest {
+
+    @Test
+    public void addProblemListenerRejectsNullAndPreventsDuplicates() {
+        FakeProblem problem = new FakeProblem();
+        CountingListener listener = new CountingListener();
+
+        assertThrows(NullPointerException.class, () -> problem.addProblemListener(null));
+
+        problem.addProblemListener(listener);
+        problem.addProblemListener(listener);
+
+        assertEquals(1, problem.getProblemListeners().size());
+    }
+
+    @Test
+    public void stepAndUndoDriveExecutionAndNotifications() {
+        FakeProblem problem = new FakeProblem();
+        CountingListener listener = new CountingListener();
+        problem.addProblemListener(listener);
+
+        problem.step();
+        assertEquals(1, problem.executeCount);
+        assertEquals(1, listener.updateCount);
+
+        problem.undo();
+        assertEquals(1, problem.undoCount);
+        assertEquals(2, listener.updateCount);
+        assertEquals(0, problem.getNextLineNumber());
+    }
+
+    @Test
+    public void undoOnEmptyHistoryAndMissingMethodAreSafeNoOps() {
+        FakeProblem problem = new FakeProblem();
+
+        problem.undo();
+        problem.executeMethod("doesNotExist");
+
+        assertEquals(0, problem.undoCount);
+    }
+
+    @Test
+    public void gettersAndTableAccessReturnExpectedValues() {
+        FakeProblem problem = new FakeProblem();
+
+        assertNotNull(problem.getVariableNames());
+        assertEquals(7, problem.getVariableValue("scalar"));
+        assertEquals(2, problem.getValueAt(0, 1));
+        assertEquals(100, problem.getBacktrackingStartNum());
+        assertEquals(-1, problem.decode(0, 0));
+    }
+
+    @Test
+    public void getVariableObjectHandlesNullVariablesMap() throws Exception {
+        FakeProblem problem = new FakeProblem();
+
+        Field variablesField = Problem.class.getDeclaredField("variables");
+        variablesField.setAccessible(true);
+        variablesField.set(problem, null);
+
+        assertNull(problem.getVariableObject("scalar"));
+    }
+
+    @Test
+    public void problemSettersAndBatchUndoUpdateState() {
+        FakeProblem problem = new FakeProblem();
+
+        problem.setSubTypeId(55);
+        problem.setTaskId(99);
+        problem.setNextLineNumber(3);
+
+        ArrayList<String> code = new ArrayList<>();
+        code.add("line1");
+        problem.setCodeStatements(code);
+
+        ArrayList<String> backtracking = new ArrayList<>();
+        backtracking.add("back1");
+        problem.setBacktrackingCodeStatements(backtracking);
+
+        problem.step();
+        problem.step();
+        problem.undo(2);
+
+        assertEquals(55, problem.getSubTypeId());
+        assertEquals(99, problem.getTaskId());
+        assertEquals(1, problem.getCodeStatements().size());
+        assertEquals(1, problem.getBacktrackingCodeStatements().size());
+        assertEquals(0, problem.undoCount);
+    }
+
+    @Test
+    public void stepNUsesTimerAndStopsWhenFinished() {
+        FakeProblem problem = new FakeProblem();
+        CountingListener listener = new CountingListener();
+        problem.addProblemListener(listener);
+
+        problem.finishOnNextStep = true;
+        problem.step(3);
+
+        long deadline = System.currentTimeMillis() + 1500;
+        while (problem.executeCount == 0 && System.currentTimeMillis() < deadline) {
+            Thread.yield();
+        }
+
+        assertTrue(problem.executeCount >= 1);
+        assertTrue(listener.updateCount >= 1);
+    }
+
+    private static class CountingListener implements ProblemListener {
+        int updateCount = 0;
+
+        @Override
+        public void problemUpdated(Problem problem) {
+            updateCount++;
+        }
+    }
+
+    private static class FakeProblem extends Problem {
+        int executeCount = 0;
+        int undoCount = 0;
+        boolean finishOnNextStep = false;
+        boolean finished = false;
+
+        FakeProblem() {
+            super(1);
+            setTableVariable("table");
+            variables.put("scalar", 7);
+            variables.put("table", new int[][] {{1, 2}, {3, 4}});
+        }
+
+        @Override
+        public ProblemKind getType() {
+            return ProblemKind.LCS_PROBLEM;
+        }
+
+        @Override
+        public boolean hasFinished() {
+            return finished;
+        }
+
+        @Override
+        public void reset() {
+            setNextLineNumber(0);
+        }
+
+        @Override
+        protected void loadCodeStatements() {}
+
+        @Override
+        protected void loadBacktrackingCodeStatements() {}
+
+        @Override
+        public boolean canStepBack() {
+            return getNextLineNumber() > 0;
+        }
+
+        @Override
+        public boolean backtrackReady() {
+            return false;
+        }
+
+        @Override
+        public void backtrackingOn() {
+            setNextLineNumber(getBacktrackingStartNum());
+        }
+
+        @Override
+        public boolean undoingBacktrackButton() {
+            return false;
+        }
+
+        @SuppressWarnings("unused")
+        private void executeLine0() {
+            executeCount++;
+            if (finishOnNextStep) {
+                finished = true;
+            }
+        }
+
+        @SuppressWarnings("unused")
+        private void undoLine0() {
+            undoCount++;
+        }
+
+        int decode(int row, int col) {
+            return TableToLineNumberdecoder(row, col);
+        }
+    }
+}

--- a/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
@@ -133,7 +133,7 @@ public class ProblemCoreTest {
         problem.finishOnNextStep = true;
         problem.step(3);
 
-        assertTrue(latch.await(6, TimeUnit.SECONDS), "Timer callback did not fire within 6s");
+        assertTrue(latch.await(2, TimeUnit.SECONDS), "Timer callback did not fire within 2s");
         assertTrue(problem.executeCount >= 1);
         assertTrue(listener.updateCount >= 1);
     }

--- a/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemCoreTest.java
@@ -14,6 +14,8 @@ package edu.regis.dptu.test;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
@@ -107,6 +109,8 @@ public class ProblemCoreTest {
         backtracking.add("back1");
         problem.setBacktrackingCodeStatements(backtracking);
 
+        // Reset to line 0 so executeLine0/undoLine0 are invoked by step/undo.
+        problem.setNextLineNumber(0);
         problem.step();
         problem.step();
         problem.undo(2);
@@ -115,28 +119,21 @@ public class ProblemCoreTest {
         assertEquals(99, problem.getTaskId());
         assertEquals(1, problem.getCodeStatements().size());
         assertEquals(1, problem.getBacktrackingCodeStatements().size());
-        assertEquals(0, problem.undoCount);
+        assertEquals(2, problem.undoCount);
     }
 
     @Test
-    public void stepNUsesTimerAndStopsWhenFinished() {
+    public void stepNUsesTimerAndStopsWhenFinished() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         FakeProblem problem = new FakeProblem();
         CountingListener listener = new CountingListener();
         problem.addProblemListener(listener);
+        problem.addProblemListener(p -> latch.countDown());
 
         problem.finishOnNextStep = true;
         problem.step(3);
 
-        long deadline = System.currentTimeMillis() + 6000;
-        while (problem.executeCount == 0 && System.currentTimeMillis() < deadline) {
-            try {
-                Thread.sleep(25);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-
+        assertTrue(latch.await(6, TimeUnit.SECONDS), "Timer callback did not fire within 6s");
         assertTrue(problem.executeCount >= 1);
         assertTrue(listener.updateCount >= 1);
     }

--- a/src/test/java/edu/regis/dptu/test/ProblemDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemDAOTest.java
@@ -1,0 +1,203 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.regis.dptu.dao.ProblemDAO;
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.ProblemKind;
+
+@SuppressWarnings("Logging")
+public class ProblemDAOTest {
+    private ProblemDAO dao;
+    private Connection mockConnection;
+    private MockedStatic<DriverManager> mockedDriverManager;
+
+    @BeforeEach
+    public void setUp() throws SQLException {
+        dao = new ProblemDAO();
+        mockConnection = mock(Connection.class);
+
+        mockedDriverManager = mockStatic(DriverManager.class);
+        mockedDriverManager
+                .when(() -> DriverManager.getConnection(anyString()))
+                .thenReturn(mockConnection);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (mockedDriverManager != null) {
+            mockedDriverManager.close();
+        }
+    }
+
+    @Test
+    public void retrieveReturnsLcsProblemWithMetadata() throws Exception {
+        PreparedStatement mainStmt = mock(PreparedStatement.class);
+        PreparedStatement subTypeStmt = mock(PreparedStatement.class);
+        ResultSet mainRs = mock(ResultSet.class);
+        ResultSet subTypeRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT ProblemType")))
+                .thenReturn(mainStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT Sequence1")))
+                .thenReturn(subTypeStmt);
+
+        when(mainStmt.executeQuery()).thenReturn(mainRs);
+        when(subTypeStmt.executeQuery()).thenReturn(subTypeRs);
+
+        when(mainRs.next()).thenReturn(true);
+        when(mainRs.getString(1)).thenReturn(ProblemKind.LCS_PROBLEM.name());
+        when(mainRs.getInt(2)).thenReturn(11);
+        when(mainRs.getString(3)).thenReturn("Top title");
+        when(mainRs.getString(4)).thenReturn("Top description");
+
+        when(subTypeRs.next()).thenReturn(true);
+        when(subTypeRs.getString(1)).thenReturn("ABC");
+        when(subTypeRs.getString(2)).thenReturn("AFC");
+
+        Problem result = dao.retrieve(5);
+
+        assertTrue(result instanceof LCSProblem);
+        assertEquals(5, result.getId());
+        assertEquals(11, result.getSubTypeId());
+        assertEquals("Top title", result.getTitle());
+        assertEquals("Top description", result.getDescription());
+        verify(mainStmt).setInt(1, 5);
+        verify(subTypeStmt).setInt(1, 11);
+    }
+
+    @Test
+    public void retrieveByKindReturnsTaskIdWhenPresent() throws Exception {
+        PreparedStatement mainStmt = mock(PreparedStatement.class);
+        PreparedStatement subTypeStmt = mock(PreparedStatement.class);
+        PreparedStatement taskStmt = mock(PreparedStatement.class);
+        ResultSet mainRs = mock(ResultSet.class);
+        ResultSet subTypeRs = mock(ResultSet.class);
+        ResultSet taskRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT Id, SubTypeId")))
+                .thenReturn(mainStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT Sequence1")))
+                .thenReturn(subTypeStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT TaskId"))).thenReturn(taskStmt);
+
+        when(mainStmt.executeQuery()).thenReturn(mainRs);
+        when(subTypeStmt.executeQuery()).thenReturn(subTypeRs);
+        when(taskStmt.executeQuery()).thenReturn(taskRs);
+
+        when(mainRs.next()).thenReturn(true);
+        when(mainRs.getInt(1)).thenReturn(7);
+        when(mainRs.getInt(2)).thenReturn(3);
+        when(mainRs.getString(3)).thenReturn("Kind title");
+        when(mainRs.getString(4)).thenReturn("Kind description");
+
+        when(subTypeRs.next()).thenReturn(true);
+        when(subTypeRs.getString(1)).thenReturn("XMJYAUZ");
+        when(subTypeRs.getString(2)).thenReturn("MZJAWXU");
+
+        when(taskRs.next()).thenReturn(true);
+        when(taskRs.getInt(1)).thenReturn(42);
+
+        Problem result = dao.retrieveByKind(ProblemKind.LCS_PROBLEM);
+
+        assertEquals(7, result.getId());
+        assertEquals(42, result.getTaskId());
+        assertEquals("Kind title", result.getTitle());
+    }
+
+    @Test
+    public void retrieveByKindReturnsMinusOneWhenTaskIsMissing() throws Exception {
+        PreparedStatement mainStmt = mock(PreparedStatement.class);
+        PreparedStatement subTypeStmt = mock(PreparedStatement.class);
+        PreparedStatement taskStmt = mock(PreparedStatement.class);
+        ResultSet mainRs = mock(ResultSet.class);
+        ResultSet subTypeRs = mock(ResultSet.class);
+        ResultSet taskRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT Id, SubTypeId")))
+                .thenReturn(mainStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT Sequence1")))
+                .thenReturn(subTypeStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT TaskId"))).thenReturn(taskStmt);
+
+        when(mainStmt.executeQuery()).thenReturn(mainRs);
+        when(subTypeStmt.executeQuery()).thenReturn(subTypeRs);
+        when(taskStmt.executeQuery()).thenReturn(taskRs);
+
+        when(mainRs.next()).thenReturn(true);
+        when(mainRs.getInt(1)).thenReturn(9);
+        when(mainRs.getInt(2)).thenReturn(2);
+        when(mainRs.getString(3)).thenReturn("Title");
+        when(mainRs.getString(4)).thenReturn("Description");
+
+        when(subTypeRs.next()).thenReturn(true);
+        when(subTypeRs.getString(1)).thenReturn("AB");
+        when(subTypeRs.getString(2)).thenReturn("AC");
+
+        when(taskRs.next()).thenReturn(false);
+
+        Problem result = dao.retrieveByKind(ProblemKind.LCS_PROBLEM);
+
+        assertEquals(-1, result.getTaskId());
+    }
+
+    @Test
+    public void retrieveThrowsObjNotFoundWhenMissing() throws Exception {
+        PreparedStatement mainStmt = mock(PreparedStatement.class);
+        ResultSet mainRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT ProblemType")))
+                .thenReturn(mainStmt);
+        when(mainStmt.executeQuery()).thenReturn(mainRs);
+        when(mainRs.next()).thenReturn(false);
+
+        assertThrows(ObjNotFoundException.class, () -> dao.retrieve(1001));
+    }
+
+    @Test
+    public void retrieveByKindWrapsSqlExceptions() throws Exception {
+        SQLException sqlEx = mock(SQLException.class);
+        when(mockConnection.prepareStatement(anyString())).thenThrow(sqlEx);
+
+        NonRecoverableException ex =
+                assertThrows(
+                        NonRecoverableException.class,
+                        () -> dao.retrieveByKind(ProblemKind.LCS_PROBLEM));
+
+        assertTrue(ex.getMessage().contains("ProblemDAO-ERR-2"));
+    }
+}

--- a/src/test/java/edu/regis/dptu/test/ProblemDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/ProblemDAOTest.java
@@ -68,16 +68,21 @@ public class ProblemDAOTest {
     public void retrieveReturnsLcsProblemWithMetadata() throws Exception {
         PreparedStatement mainStmt = mock(PreparedStatement.class);
         PreparedStatement subTypeStmt = mock(PreparedStatement.class);
+        PreparedStatement taskStmt = mock(PreparedStatement.class);
         ResultSet mainRs = mock(ResultSet.class);
         ResultSet subTypeRs = mock(ResultSet.class);
+        ResultSet taskRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(startsWith("SELECT ProblemType")))
                 .thenReturn(mainStmt);
         when(mockConnection.prepareStatement(startsWith("SELECT Sequence1")))
                 .thenReturn(subTypeStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT TaskId"))).thenReturn(taskStmt);
 
         when(mainStmt.executeQuery()).thenReturn(mainRs);
         when(subTypeStmt.executeQuery()).thenReturn(subTypeRs);
+        when(taskStmt.executeQuery()).thenReturn(taskRs);
+        when(taskRs.next()).thenReturn(false);
 
         when(mainRs.next()).thenReturn(true);
         when(mainRs.getString(1)).thenReturn(ProblemKind.LCS_PROBLEM.name());

--- a/src/test/java/edu/regis/dptu/test/ResourceMgrAndImgFactoryTest.java
+++ b/src/test/java/edu/regis/dptu/test/ResourceMgrAndImgFactoryTest.java
@@ -60,12 +60,10 @@ public class ResourceMgrAndImgFactoryTest {
     public void imgFactoryMissingImagesReturnNullImageAndIconWithAltText() {
         assertNull(ImgFactory.createImage("missing-file.png"));
 
-        assertThrows(
-                NullPointerException.class,
-                () -> ImgFactory.createIcon("missing-file.png", "fallback"));
-
-        ImageIcon icon = new ImageIcon();
+        ImageIcon icon = ImgFactory.createIcon("missing-file.png", "fallback");
         assertNotNull(icon);
+        assertEquals("fallback", icon.getDescription());
         assertTrue(icon.getIconWidth() <= 0);
+        assertTrue(icon.getIconHeight() <= 0);
     }
 }

--- a/src/test/java/edu/regis/dptu/test/ResourceMgrAndImgFactoryTest.java
+++ b/src/test/java/edu/regis/dptu/test/ResourceMgrAndImgFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.test;
+
+import javax.swing.ImageIcon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.regis.dptu.err.MissingPropertyException;
+import edu.regis.dptu.util.ImgFactory;
+import edu.regis.dptu.util.ResourceMgr;
+
+@SuppressWarnings("Logging")
+public class ResourceMgrAndImgFactoryTest {
+
+    @Test
+    public void resourceMgrReturnsLocaleAndKnownProperties() throws Exception {
+        ResourceMgr mgr = ResourceMgr.instance();
+
+        assertNotNull(mgr.getLocale());
+        assertNotNull(mgr.getProp("language"));
+        assertNotNull(mgr.getProp("country"));
+    }
+
+    @Test
+    public void resourceMgrMissingKeysReturnPlaceholderPattern() {
+        ResourceMgr mgr = ResourceMgr.instance();
+
+        String value = mgr.string("not.a.real.key");
+        String formatted = mgr.string("not.a.real.key", "arg");
+
+        assertEquals("!!not.a.real.key!!", value);
+        assertEquals("!!not.a.real.key!!", formatted);
+    }
+
+    @Test
+    public void resourceMgrMissingPropertyThrows() {
+        ResourceMgr mgr = ResourceMgr.instance();
+
+        assertThrows(MissingPropertyException.class, () -> mgr.getProp("not_a_property"));
+    }
+
+    @Test
+    public void imgFactoryMissingImagesReturnNullImageAndIconWithAltText() {
+        assertNull(ImgFactory.createImage("missing-file.png"));
+
+        assertThrows(
+                NullPointerException.class,
+                () -> ImgFactory.createIcon("missing-file.png", "fallback"));
+
+        ImageIcon icon = new ImageIcon();
+        assertNotNull(icon);
+        assertTrue(icon.getIconWidth() <= 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add focused DAO/service/model/util tests to improve non-UI coverage
- keep Swing UI classes out of the target metric
- validate with clean Maven verify + JaCoCo report

## Validation
- mvn clean verify
- non-UI line coverage (excluding edu.regis.dptu.view*): 90.22%