### PR TITLE
DPTU-180: Session save/resume

### DIFF
--- a/database/setup_DpTuDB.sql
+++ b/database/setup_DpTuDB.sql
@@ -107,6 +107,11 @@ CREATE TABLE TutoringSession (
     'KNAPSACK_0_1'
    ),
    ProblemId INT NOT NULL,
+  Mode ENUM(
+    'SEE_ONE',
+    'DO_ONE',
+    'TEACH_ONE'
+  ) DEFAULT 'SEE_ONE',
 
    PRIMARY KEY (SessionId),
    FOREIGN KEY (UserId)

--- a/documentation/session-saving-resume-developer-guide.md
+++ b/documentation/session-saving-resume-developer-guide.md
@@ -36,7 +36,7 @@ It covers:
 - `src/main/java/edu/regis/dptu/view/act/SeeOneAction.java`
 - `src/main/java/edu/regis/dptu/view/act/DoOneAction.java`
 - `src/main/java/edu/regis/dptu/view/act/TeachOneAction.java`
-  - Prefer resuming saved session state when it matches selected mode/problem type and includes pending task data.
+  - Prefer resuming saved session state when it matches the selected mode and exact problem identity (problem id + type) and includes pending task data.
 
 - `src/main/java/edu/regis/dptu/view/act/SignInAction.java`
   - Deserializes full session JSON from server into `TutoringSession` and stores it in `SplashFrame`.

--- a/documentation/session-saving-resume-developer-guide.md
+++ b/documentation/session-saving-resume-developer-guide.md
@@ -17,7 +17,7 @@ It covers:
 2. The server returns a `TutoringSession` payload via `SIGN_IN`.
 3. The client stores this as the signed-in session in `SplashFrame`.
 4. Student starts a mode (`SEE_ONE`, `DO_ONE`, `TEACH_ONE`).
-5. If a saved session exists for that mode/problem kind with pending progress, the mode action resumes it.
+5. If a saved session exists for that mode and exact problem id with pending progress, the mode action resumes it.
 6. If no matching saved progress exists, a fresh in-memory lesson session is created.
 7. When the student triggers Save, `SaveSessionAction` writes session metadata and pending progress.
 
@@ -59,6 +59,12 @@ Relevant columns:
 - `ProblemId`
 - `Mode` (new)
 
+Why `Mode` is required:
+
+- A single signed-in user can work in different tutoring modes (`SEE_ONE`, `DO_ONE`, `TEACH_ONE`) that may target the same problem type.
+- Without persisting mode, resume logic cannot reliably determine which pedagogical flow should be restored.
+- Persisting mode prevents cross-mode accidental resume (for example, resuming a `DO_ONE` session when launching `SEE_ONE`).
+
 ### PendingTask and PendingStep tables
 
 These tables store resumable in-progress state for the active task/step:
@@ -86,7 +92,7 @@ Each mode action resumes only when all of these are true:
 
 - saved session mode equals action mode
 - saved session has a problem
-- saved session problem kind equals selected problem kind
+- saved session problem id and kind both match selected problem
 - saved session has pending task data
 
 Otherwise, action falls back to creating a fresh session scaffold.
@@ -109,6 +115,21 @@ For existing databases created before this change, add a migration before runnin
 ```sql
 ALTER TABLE TutoringSession
 ADD COLUMN Mode ENUM('SEE_ONE', 'DO_ONE', 'TEACH_ONE') DEFAULT 'SEE_ONE';
+```
+
+Recommended migration path:
+
+1. Add the `Mode` column as shown above.
+2. Backfill any null/unknown values to `SEE_ONE`.
+3. Deploy application code that reads/writes mode.
+4. Verify saved sessions can be resumed per mode in a lower environment before production rollout.
+
+Optional backfill SQL:
+
+```sql
+UPDATE TutoringSession
+SET Mode = 'SEE_ONE'
+WHERE Mode IS NULL;
 ```
 
 ## Tests
@@ -148,6 +169,12 @@ Not yet persisted:
 
 - full algorithm runtime state inside `Problem` (for example full DP table execution position history)
 - multiple pending tasks per session beyond active task row
+
+Why the single pending task/step limitation is a problem:
+
+- If a learning flow queues more than one pending task, only the active row is currently restorable.
+- Learners can resume into the right task but still lose downstream queued task context.
+- This is acceptable for single-active-task flows but should be expanded if multi-task continuity becomes a requirement.
 
 If full algorithm-level runtime replay is needed, extend `Problem` persistence separately.
 

--- a/documentation/session-saving-resume-developer-guide.md
+++ b/documentation/session-saving-resume-developer-guide.md
@@ -1,0 +1,162 @@
+# Session Saving and Resuming Developer Guide
+
+## Purpose
+
+This guide explains how tutoring session save/resume works in DpTu after the session persistence enhancements.
+
+It covers:
+
+- what state is saved
+- where the state is stored
+- how state is restored on sign-in and lesson launch
+- how to test and extend the behavior
+
+## High-Level Flow
+
+1. Student signs in.
+2. The server returns a `TutoringSession` payload via `SIGN_IN`.
+3. The client stores this as the signed-in session in `SplashFrame`.
+4. Student starts a mode (`SEE_ONE`, `DO_ONE`, `TEACH_ONE`).
+5. If a saved session exists for that mode/problem kind with pending progress, the mode action resumes it.
+6. If no matching saved progress exists, a fresh in-memory lesson session is created.
+7. When the student triggers Save, `SaveSessionAction` writes session metadata and pending progress.
+
+## Primary Classes
+
+- `src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java`
+  - Handles user Save action.
+  - Calls `SessionSvc.update(...)` with fallback to `create(...)` if the session is missing.
+  - Shows user-visible success/error dialogs.
+
+- `src/main/java/edu/regis/dptu/dao/SessionDAO.java`
+  - Persists `TutoringSession` metadata (token, course, unit, mode, active flag).
+  - Persists current pending task/step state.
+  - Restores pending task/step state on retrieve.
+
+- `src/main/java/edu/regis/dptu/view/act/SeeOneAction.java`
+- `src/main/java/edu/regis/dptu/view/act/DoOneAction.java`
+- `src/main/java/edu/regis/dptu/view/act/TeachOneAction.java`
+  - Prefer resuming saved session state when it matches selected mode/problem type and includes pending task data.
+
+- `src/main/java/edu/regis/dptu/view/act/SignInAction.java`
+  - Deserializes full session JSON from server into `TutoringSession` and stores it in `SplashFrame`.
+
+## Persistence Model
+
+### TutoringSession table
+
+`SessionDAO` create/update now persists mode in addition to existing session metadata.
+
+Relevant columns:
+
+- `SessionId`
+- `SecurityToken`
+- `UserId`
+- `CourseId`
+- `UnitId`
+- `IsActive`
+- `ProblemType`
+- `ProblemId`
+- `Mode` (new)
+
+### PendingTask and PendingStep tables
+
+These tables store resumable in-progress state for the active task/step:
+
+- `PendingTask(SessionId, TaskId, PendingStepId)`
+- `PendingStep(Id, SessionId, StepId, NotifyTutor, IsCompleted, CurrentHintIndex)`
+
+On save/update:
+
+1. Existing pending progress rows for the session are deleted.
+2. Current pending step is inserted in `PendingStep`.
+3. Current pending task is inserted in `PendingTask` linked to the inserted pending step.
+
+On retrieve:
+
+1. Session metadata is loaded from `TutoringSession`.
+2. Problem is loaded via `ProblemSvc`.
+3. Pending task/step row is joined and loaded.
+4. Task and steps are loaded via `CourseSvc.retrieveTask(...)`.
+5. Pending step flags and hint index are restored.
+
+## Resume Decision in Mode Actions
+
+Each mode action resumes only when all of these are true:
+
+- saved session mode equals action mode
+- saved session has a problem
+- saved session problem kind equals selected problem kind
+- saved session has pending task data
+
+Otherwise, action falls back to creating a fresh session scaffold.
+
+## Save Action Feedback Behavior
+
+`SaveSessionAction` feedback outcomes:
+
+- No active lesson session: informational dialog
+- Save success (`update`): informational dialog
+- Missing session (`ObjNotFoundException`): fallback to `create` then informational dialog
+- Save/create failure: error dialog
+
+## Database Setup Note
+
+`database/setup_DpTuDB.sql` includes `Mode` on `TutoringSession`.
+
+For existing databases created before this change, add a migration before running new save/resume logic. Example:
+
+```sql
+ALTER TABLE TutoringSession
+ADD COLUMN Mode ENUM('SEE_ONE', 'DO_ONE', 'TEACH_ONE') DEFAULT 'SEE_ONE';
+```
+
+## Tests
+
+### Save action integration tests
+
+- `src/test/java/edu/regis/dptu/view/act/SaveSessionActionIntegrationTest.java`
+
+Covers:
+
+- successful save
+- missing-session fallback create
+- no active session feedback
+- persistence failure feedback
+
+### Session DAO tests
+
+- `src/test/java/edu/regis/dptu/test/SessionDAOTest.java`
+
+Covers:
+
+- mode persistence in create/update/retrieve
+- pending progress persistence during save/update
+- pending progress rehydration during retrieve
+
+## Current Scope and Limitations
+
+Current save/resume persists and restores:
+
+- session metadata
+- mode
+- active pending task ID
+- active pending step ID
+- pending step flags/hint index
+
+Not yet persisted:
+
+- full algorithm runtime state inside `Problem` (for example full DP table execution position history)
+- multiple pending tasks per session beyond active task row
+
+If full algorithm-level runtime replay is needed, extend `Problem` persistence separately.
+
+## Extension Guidance
+
+If extending save/resume:
+
+1. Add schema fields/tables first.
+2. Keep all session save operations transactional in DAO methods.
+3. Extend `SessionDAO.persistPendingProgress(...)` and `loadPendingProgress(...)` together.
+4. Add/update both DAO tests and action-level integration tests.
+5. Keep user-facing feedback text in `Msgs.properties`.

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -77,15 +77,15 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
 
         try {
             conn = DriverManager.getConnection(URL);
+            conn.setAutoCommit(false);
             log.debug("Database connection established for creating session id={}", sessionId);
 
-            if (exists(sessionId, conn)) {
+            if (sessionId > 0 && exists(sessionId, conn)) {
                 log.warn("Session already exists with id={}", sessionId);
                 throw new IllegalArgException("Session already exists with id " + sessionId);
             }
 
-            String[] keyCol = {"SessionId"};
-            stmt = conn.prepareStatement(sql, keyCol);
+            stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             stmt.setString(1, session.getSecurityToken());
             stmt.setString(2, session.getUserId());
             stmt.setInt(3, session.getCourse().getId());
@@ -99,10 +99,29 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
                     8, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
 
             int rows = stmt.executeUpdate();
+
+            ResultSet generatedKeys = stmt.getGeneratedKeys();
+            if (generatedKeys.next()) {
+                sessionId = generatedKeys.getInt(1);
+                session.setId(sessionId);
+            } else if (sessionId <= 0) {
+                conn.rollback();
+                throw new NonRecoverableException(
+                        "Create Session Error: missing generated SessionId");
+            }
+
             log.debug("Session created successfully id={}, rows affected={}", sessionId, rows);
 
             persistPendingProgress(session, conn);
+            conn.commit();
         } catch (SQLException e) {
+            try {
+                if (conn != null) {
+                    conn.rollback();
+                }
+            } catch (SQLException rollbackEx) {
+                log.warn("Rollback failed while creating session id={}", sessionId, rollbackEx);
+            }
             log.error("SQLException creating session id={}", sessionId, e);
             throw new NonRecoverableException("Create Session Error", e);
         } finally {

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -18,6 +18,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.GregorianCalendar;
 
 import org.slf4j.Logger;
@@ -26,9 +27,19 @@ import org.slf4j.LoggerFactory;
 import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.CourseDigest;
+import edu.regis.dptu.model.Model;
+import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.PendingStep;
+import edu.regis.dptu.model.PendingTask;
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.Step;
+import edu.regis.dptu.model.StepSubType;
 import edu.regis.dptu.model.Student;
+import edu.regis.dptu.model.Task;
 import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.model.UnitDigest;
+import edu.regis.dptu.svc.CourseSvc;
 import edu.regis.dptu.svc.ProblemSvc;
 import edu.regis.dptu.svc.ServiceFactory;
 import edu.regis.dptu.svc.SessionSvc;
@@ -58,7 +69,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             throws IllegalArgException, NonRecoverableException {
         log.debug("Creating session id={}", session.getId());
         final String sql =
-                "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemType, ProblemId) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?)";
+            "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemType, ProblemId, Mode) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?,?)";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -84,9 +95,12 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             Problem prob = session.getProblem();
             stmt.setString(6, prob.getType().toString());
             stmt.setInt(7, prob.getId());
+            stmt.setString(8, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
 
             int rows = stmt.executeUpdate();
             log.debug("Session created successfully id={}, rows affected={}", sessionId, rows);
+
+            persistPendingProgress(session, conn);
         } catch (SQLException e) {
             log.error("SQLException creating session id={}", sessionId, e);
             throw new NonRecoverableException("Create Session Error", e);
@@ -102,7 +116,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
         String userId = student.getAccount().getUserId();
         log.debug("Retrieving session for userId={}", userId);
         final String sql =
-                "SELECT SessionId, SecurityToken, StartDate, IsActive, ProblemType, ProblemId FROM TutoringSession WHERE UserId = ?";
+            "SELECT SessionId, SecurityToken, StartDate, IsActive, CourseId, UnitId, ProblemType, ProblemId, Mode FROM TutoringSession WHERE UserId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -123,9 +137,14 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
                 date.setTime(rs.getDate(3));
                 session.setStartDate(date);
                 session.setIsActive(rs.getBoolean(4));
+                session.setCourse(new CourseDigest(rs.getInt(5)));
+                session.setUnit(new UnitDigest(rs.getInt(6)));
+                String modeName = rs.getString(9);
+                session.setMode(modeName == null ? Mode.SEE_ONE : Mode.valueOf(modeName));
 
                 ProblemSvc problemSvc = ServiceFactory.findProblemSvc();
-                session.setProblem(problemSvc.retrieve(rs.getInt(6)));
+                session.setProblem(problemSvc.retrieve(rs.getInt(8)));
+                loadPendingProgress(session, rs.getInt(5), conn);
 
                 log.debug(
                         "Session retrieved successfully for userId={}, sessionId={}",
@@ -183,7 +202,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             throws ObjNotFoundException, NonRecoverableException {
         log.debug("Updating session id={}", session.getId());
         final String sql =
-                "UPDATE TutoringSession SET SecurityToken = ?, CourseId = ?, UnitId = ?, IsActive = ? WHERE SessionId = ?";
+            "UPDATE TutoringSession SET SecurityToken = ?, CourseId = ?, UnitId = ?, IsActive = ?, Mode = ? WHERE SessionId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -197,7 +216,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             stmt.setInt(2, session.getCourse().getId());
             stmt.setInt(3, session.getUnit().getId());
             stmt.setBoolean(4, session.isIsActive());
-            stmt.setInt(5, session.getId());
+            stmt.setString(5, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
+            stmt.setInt(6, session.getId());
 
             int rows = stmt.executeUpdate();
 
@@ -209,6 +229,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
                         session.getId());
                 throw new NonRecoverableException("Session update updated too many rows: " + rows);
             }
+
+            persistPendingProgress(session, conn);
 
             conn.commit();
             log.debug("Session updated successfully sessionId={}", session.getId());
@@ -224,14 +246,24 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
     @Override
     public void delete(String userId) throws NonRecoverableException {
         log.debug("Deleting session for userId={}", userId);
+        final String lookupSql = "SELECT SessionId FROM TutoringSession WHERE UserId = ?";
         final String sql = "DELETE FROM TutoringSession WHERE UserId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
+        PreparedStatement lookupStmt = null;
 
         try {
             conn = DriverManager.getConnection(URL);
             conn.setAutoCommit(false);
+
+            lookupStmt = conn.prepareStatement(lookupSql);
+            lookupStmt.setString(1, userId);
+            ResultSet rs = lookupStmt.executeQuery();
+            if (rs.next()) {
+                clearPendingProgress(rs.getInt(1), conn);
+            }
+
             stmt = conn.prepareStatement(sql);
             stmt.setString(1, userId);
 
@@ -252,7 +284,134 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             log.error("SQLException deleting session for userId={}", userId, e);
             throw new NonRecoverableException("Delete Session Error", e);
         } finally {
+            close(lookupStmt);
             close(conn, stmt);
+        }
+    }
+
+    private void persistPendingProgress(TutoringSession session, Connection conn)
+            throws SQLException {
+        int sessionId = session.getId();
+        clearPendingProgress(sessionId, conn);
+
+        if (session.getTasks() == null || session.getTasks().isEmpty()) {
+            return;
+        }
+
+        PendingTask pendingTask = session.getCurrentTask();
+        if (pendingTask == null || pendingTask.getTask() == null) {
+            return;
+        }
+
+        PendingStep pendingStep = pendingTask.getCurrentStep();
+        if (pendingStep == null || pendingStep.getStep() == null) {
+            return;
+        }
+
+        final String pendingStepSql =
+                "INSERT INTO PendingStep(SessionId, StepId, NotifyTutor, IsCompleted, CurrentHintIndex) VALUES (?,?,?,?,?)";
+        final String pendingTaskSql =
+                "INSERT INTO PendingTask(SessionId, TaskId, PendingStepId) VALUES (?,?,?)";
+
+        try (PreparedStatement insertStepStmt =
+                conn.prepareStatement(pendingStepSql, Statement.RETURN_GENERATED_KEYS);
+                PreparedStatement insertTaskStmt = conn.prepareStatement(pendingTaskSql)) {
+            insertStepStmt.setInt(1, sessionId);
+            insertStepStmt.setInt(2, pendingStep.getStep().getId());
+            insertStepStmt.setBoolean(3, pendingStep.isNotifyTutor());
+            insertStepStmt.setBoolean(4, pendingStep.isCompleted());
+            insertStepStmt.setInt(5, pendingStep.getCurrentHintIndex());
+            insertStepStmt.executeUpdate();
+
+            int pendingStepId = Model.DEFAULT_ID;
+            ResultSet keys = insertStepStmt.getGeneratedKeys();
+            if (keys.next()) {
+                pendingStepId = keys.getInt(1);
+            }
+
+            if (pendingStepId == Model.DEFAULT_ID) {
+                throw new SQLException("Unable to persist PendingStep for session " + sessionId);
+            }
+
+            insertTaskStmt.setInt(1, sessionId);
+            insertTaskStmt.setInt(2, pendingTask.getTask().getId());
+            insertTaskStmt.setInt(3, pendingStepId);
+            insertTaskStmt.executeUpdate();
+        }
+    }
+
+    private void loadPendingProgress(TutoringSession session, int courseId, Connection conn)
+            throws NonRecoverableException {
+        final String sql =
+                "SELECT pt.TaskId, ps.Id, ps.StepId, ps.NotifyTutor, ps.IsCompleted, ps.CurrentHintIndex "
+                        + "FROM PendingTask pt JOIN PendingStep ps ON pt.PendingStepId = ps.Id "
+                        + "WHERE pt.SessionId = ?";
+
+        PreparedStatement stmt = null;
+        try {
+            stmt = conn.prepareStatement(sql);
+            stmt.setInt(1, session.getId());
+            ResultSet rs = stmt.executeQuery();
+
+            if (!rs.next()) {
+                return;
+            }
+
+            int taskId = rs.getInt(1);
+            int pendingStepId = rs.getInt(2);
+            int stepId = rs.getInt(3);
+            boolean notifyTutor = rs.getBoolean(4);
+            boolean isCompleted = rs.getBoolean(5);
+            int currentHintIndex = rs.getInt(6);
+
+            Task task = loadTask(courseId, taskId, conn);
+            task.setProblem(session.getProblem());
+
+            Step step = task.findStepById(stepId);
+            if (step == null) {
+                step = new Step(stepId, 0, StepSubType.INFO_MESSAGE);
+            }
+
+            PendingStep pendingStep = new PendingStep(pendingStepId, step);
+            pendingStep.setNotifyTutor(notifyTutor);
+            pendingStep.setIsCompleted(isCompleted);
+            pendingStep.setCurrentHintIndex(currentHintIndex);
+
+            PendingTask pendingTask = new PendingTask(task);
+            pendingTask.setCurrentStep(pendingStep);
+            session.addTask(pendingTask);
+        } catch (SQLException e) {
+            throw new NonRecoverableException("Load Pending Progress Error", e);
+        } finally {
+            close(stmt);
+        }
+    }
+
+    private Task loadTask(int courseId, int taskId, Connection conn) {
+        try {
+            CourseSvc courseSvc = ServiceFactory.findCourseSvc();
+            return courseSvc.retrieveTask(courseId, taskId, conn);
+        } catch (ObjNotFoundException | NonRecoverableException ex) {
+            log.warn(
+                    "Unable to load Task {} for course {} while restoring session; using lightweight fallback",
+                    taskId,
+                    courseId,
+                    ex);
+            return new Task(taskId);
+        }
+    }
+
+    private void clearPendingProgress(int sessionId, Connection conn) throws SQLException {
+        final String deletePendingTaskSql = "DELETE FROM PendingTask WHERE SessionId = ?";
+        final String deletePendingStepSql = "DELETE FROM PendingStep WHERE SessionId = ?";
+
+        try (PreparedStatement deletePendingTaskStmt = conn.prepareStatement(deletePendingTaskSql);
+                PreparedStatement deletePendingStepStmt = conn.prepareStatement(deletePendingStepSql)) {
+            deletePendingTaskStmt.setInt(1, sessionId);
+            deletePendingTaskStmt.executeUpdate();
+
+            deletePendingStepStmt.setInt(1, sessionId);
+            deletePendingStepStmt.executeUpdate();
         }
     }
 

--- a/src/main/java/edu/regis/dptu/dao/SessionDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/SessionDAO.java
@@ -28,8 +28,8 @@ import edu.regis.dptu.err.IllegalArgException;
 import edu.regis.dptu.err.NonRecoverableException;
 import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.CourseDigest;
-import edu.regis.dptu.model.Model;
 import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.Model;
 import edu.regis.dptu.model.PendingStep;
 import edu.regis.dptu.model.PendingTask;
 import edu.regis.dptu.model.Problem;
@@ -69,7 +69,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             throws IllegalArgException, NonRecoverableException {
         log.debug("Creating session id={}", session.getId());
         final String sql =
-            "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemType, ProblemId, Mode) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?,?)";
+                "INSERT INTO TutoringSession(SecurityToken, UserId, CourseId, UnitId, IsActive, StartDate, ProblemType, ProblemId, Mode) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP(),?,?,?)";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -95,7 +95,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             Problem prob = session.getProblem();
             stmt.setString(6, prob.getType().toString());
             stmt.setInt(7, prob.getId());
-            stmt.setString(8, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
+            stmt.setString(
+                    8, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
 
             int rows = stmt.executeUpdate();
             log.debug("Session created successfully id={}, rows affected={}", sessionId, rows);
@@ -116,7 +117,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
         String userId = student.getAccount().getUserId();
         log.debug("Retrieving session for userId={}", userId);
         final String sql =
-            "SELECT SessionId, SecurityToken, StartDate, IsActive, CourseId, UnitId, ProblemType, ProblemId, Mode FROM TutoringSession WHERE UserId = ?";
+                "SELECT SessionId, SecurityToken, StartDate, IsActive, CourseId, UnitId, ProblemType, ProblemId, Mode FROM TutoringSession WHERE UserId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -202,7 +203,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             throws ObjNotFoundException, NonRecoverableException {
         log.debug("Updating session id={}", session.getId());
         final String sql =
-            "UPDATE TutoringSession SET SecurityToken = ?, CourseId = ?, UnitId = ?, IsActive = ?, Mode = ? WHERE SessionId = ?";
+                "UPDATE TutoringSession SET SecurityToken = ?, CourseId = ?, UnitId = ?, IsActive = ?, Mode = ? WHERE SessionId = ?";
 
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -216,7 +217,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
             stmt.setInt(2, session.getCourse().getId());
             stmt.setInt(3, session.getUnit().getId());
             stmt.setBoolean(4, session.isIsActive());
-            stmt.setString(5, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
+            stmt.setString(
+                    5, (session.getMode() == null ? Mode.SEE_ONE : session.getMode()).name());
             stmt.setInt(6, session.getId());
 
             int rows = stmt.executeUpdate();
@@ -314,7 +316,7 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
                 "INSERT INTO PendingTask(SessionId, TaskId, PendingStepId) VALUES (?,?,?)";
 
         try (PreparedStatement insertStepStmt =
-                conn.prepareStatement(pendingStepSql, Statement.RETURN_GENERATED_KEYS);
+                        conn.prepareStatement(pendingStepSql, Statement.RETURN_GENERATED_KEYS);
                 PreparedStatement insertTaskStmt = conn.prepareStatement(pendingTaskSql)) {
             insertStepStmt.setInt(1, sessionId);
             insertStepStmt.setInt(2, pendingStep.getStep().getId());
@@ -406,7 +408,8 @@ public class SessionDAO extends MySqlDAO implements SessionSvc {
         final String deletePendingStepSql = "DELETE FROM PendingStep WHERE SessionId = ?";
 
         try (PreparedStatement deletePendingTaskStmt = conn.prepareStatement(deletePendingTaskSql);
-                PreparedStatement deletePendingStepStmt = conn.prepareStatement(deletePendingStepSql)) {
+                PreparedStatement deletePendingStepStmt =
+                        conn.prepareStatement(deletePendingStepSql)) {
             deletePendingTaskStmt.setInt(1, sessionId);
             deletePendingTaskStmt.executeUpdate();
 

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -84,6 +84,15 @@ public class DoOneAction extends DpTuGuiAction {
 
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             if (signedInSession != null) {
+                if (canResumeSavedSession(signedInSession, Mode.DO_ONE, problem)) {
+                    log.info(
+                            "Resuming previously saved DO_ONE sessionId={} for userId={}",
+                            signedInSession.getId(),
+                            signedInSession.getUserId());
+                    SplashFrame.instance().selectLessonScreen(signedInSession);
+                    return;
+                }
+
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
@@ -160,5 +169,22 @@ public class DoOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
+    }
+
+    private boolean canResumeSavedSession(
+            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
+        if (signedInSession.getMode() != expectedMode) {
+            return false;
+        }
+
+        if (signedInSession.getProblem() == null || selectedProblem == null) {
+            return false;
+        }
+
+        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
+            return false;
+        }
+
+        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -82,6 +82,28 @@ public class DoOneAction extends DpTuGuiAction {
             TutoringSession ts = new TutoringSession(account, problem);
             ts.setMode(Mode.DO_ONE);
 
+            TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
+            if (signedInSession != null) {
+                ts.setId(signedInSession.getId());
+                ts.setSecurityToken(signedInSession.getSecurityToken());
+                ts.setUserId(signedInSession.getUserId());
+                ts.setCourse(signedInSession.getCourse());
+                ts.setUnit(signedInSession.getUnit());
+                ts.setIsActive(signedInSession.isIsActive());
+                ts.setStartDate(signedInSession.getStartDate());
+                log.info(
+                        "Initialized DO_ONE session with existing sessionId={}, tokenPresent={}, userId={}, hasCourse={}, hasUnit={}",
+                        ts.getId(),
+                        ts.getSecurityToken() != null,
+                        ts.getUserId(),
+                        ts.getCourse() != null,
+                        ts.getUnit() != null);
+            } else {
+                log.warn(
+                        "No signed-in session found in SplashFrame; "
+                                + "DO_ONE session has no authorization context (sessionId or securityToken)");
+            }
+
             /**
              * for future students, in order to initialize a tutoring session, you need to populate
              * the task list for that session none of our constructors (there are three), do this

--- a/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/DoOneAction.java
@@ -84,7 +84,8 @@ public class DoOneAction extends DpTuGuiAction {
 
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             if (signedInSession != null) {
-                if (canResumeSavedSession(signedInSession, Mode.DO_ONE, problem)) {
+                if (SessionResumeMatcher.canResumeSavedSession(
+                        signedInSession, Mode.DO_ONE, problem)) {
                     log.info(
                             "Resuming previously saved DO_ONE sessionId={} for userId={}",
                             signedInSession.getId(),
@@ -169,22 +170,5 @@ public class DoOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
-    }
-
-    private boolean canResumeSavedSession(
-            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
-        if (signedInSession.getMode() != expectedMode) {
-            return false;
-        }
-
-        if (signedInSession.getProblem() == null || selectedProblem == null) {
-            return false;
-        }
-
-        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
-            return false;
-        }
-
-        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
@@ -14,14 +14,24 @@ package edu.regis.dptu.view.act;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
+import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.regis.dptu.err.IllegalArgException;
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.svc.ServiceFactory;
+import edu.regis.dptu.svc.SessionSvc;
 import edu.regis.dptu.util.ImgFactory;
 import edu.regis.dptu.util.ResourceMgr;
+import edu.regis.dptu.view.MainFrame;
 
 /**
  * Handler for GUI gestures requesting to save the current session.
@@ -30,6 +40,11 @@ import edu.regis.dptu.util.ResourceMgr;
  */
 public class SaveSessionAction extends DpTuGuiAction {
     private static final Logger log = LoggerFactory.getLogger(SaveSessionAction.class);
+
+    private Supplier<TutoringSession> activeSessionSupplier =
+            () -> MainFrame.instance().getView().getModel();
+    private Supplier<SessionSvc> sessionSvcSupplier = ServiceFactory::findSessionSvc;
+    private Consumer<DialogRequest> dialogPresenter = this::showDialog;
 
     /**
      * Create the singleton for this action, which occurs when this class is loaded by the Java
@@ -70,8 +85,89 @@ public class SaveSessionAction extends DpTuGuiAction {
      * @param evt
      */
     public void actionPerformed(ActionEvent evt) {
-        // ToDo: what happens on a save
-        log.warn("Save not implemented");
-        // GuiController.instance().getStepView().selectPanel("RotateView");
+        TutoringSession session = activeSessionSupplier.get();
+
+        if (session == null) {
+            log.warn("Save requested with no active tutoring session in the UI");
+            showInfo(ResourceMgr.instance().string("save.session.error.noActive"));
+            return;
+        }
+
+        SessionSvc sessionSvc = sessionSvcSupplier.get();
+
+        try {
+            sessionSvc.update(session);
+            log.info(
+                    "Session saved: sessionId={}, userId={}", session.getId(), session.getUserId());
+            showInfo(ResourceMgr.instance().string("save.session.success"));
+        } catch (ObjNotFoundException notFound) {
+            persistMissingSession(session, sessionSvc);
+        } catch (NonRecoverableException | RuntimeException ex) {
+            log.error(
+                    "Failed to save session: sessionId={}, userId={}",
+                    session.getId(),
+                    session.getUserId(),
+                    ex);
+            showError(ResourceMgr.instance().string("save.session.error.failed"));
+        }
     }
+
+    private void persistMissingSession(TutoringSession session, SessionSvc sessionSvc) {
+        try {
+            sessionSvc.create(session);
+            log.info(
+                    "Session did not exist during save; created instead: sessionId={}, userId={}",
+                    session.getId(),
+                    session.getUserId());
+            showInfo(ResourceMgr.instance().string("save.session.success"));
+        } catch (IllegalArgException | NonRecoverableException | RuntimeException ex) {
+            log.error(
+                    "Failed to create missing session during save: sessionId={}, userId={}",
+                    session.getId(),
+                    session.getUserId(),
+                    ex);
+            showError(ResourceMgr.instance().string("save.session.error.failed"));
+        }
+    }
+
+    private void showInfo(String message) {
+        dialogPresenter.accept(
+                new DialogRequest(
+                        message,
+                        ResourceMgr.instance().string("dialog.title.information"),
+                        JOptionPane.INFORMATION_MESSAGE));
+    }
+
+    private void showError(String message) {
+        dialogPresenter.accept(
+                new DialogRequest(
+                        message,
+                        ResourceMgr.instance().string("dialog.title.error"),
+                        JOptionPane.ERROR_MESSAGE));
+    }
+
+    private void showDialog(DialogRequest request) {
+        JOptionPane.showMessageDialog(
+                MainFrame.instance(), request.message(), request.title(), request.messageType());
+    }
+
+    void setActiveSessionSupplierForTest(Supplier<TutoringSession> supplier) {
+        activeSessionSupplier = supplier;
+    }
+
+    void setSessionSvcSupplierForTest(Supplier<SessionSvc> supplier) {
+        sessionSvcSupplier = supplier;
+    }
+
+    void setDialogPresenterForTest(Consumer<DialogRequest> presenter) {
+        dialogPresenter = presenter;
+    }
+
+    void resetTestOverrides() {
+        activeSessionSupplier = () -> MainFrame.instance().getView().getModel();
+        sessionSvcSupplier = ServiceFactory::findSessionSvc;
+        dialogPresenter = this::showDialog;
+    }
+
+    static record DialogRequest(String message, String title, int messageType) {}
 }

--- a/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SaveSessionAction.java
@@ -84,6 +84,7 @@ public class SaveSessionAction extends DpTuGuiAction {
      *
      * @param evt
      */
+    @Override
     public void actionPerformed(ActionEvent evt) {
         TutoringSession session = activeSessionSupplier.get();
 

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -94,6 +94,15 @@ public class SeeOneAction extends DpTuGuiAction {
                     signedInSession != null && signedInSession.getSecurityToken() != null);
 
             if (signedInSession != null) {
+                if (canResumeSavedSession(signedInSession, Mode.SEE_ONE, problem)) {
+                    log.info(
+                            "Resuming previously saved SEE_ONE sessionId={} for userId={}",
+                            signedInSession.getId(),
+                            signedInSession.getUserId());
+                    SplashFrame.instance().selectLessonScreen(signedInSession);
+                    return;
+                }
+
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
@@ -145,5 +154,22 @@ public class SeeOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
+    }
+
+    private boolean canResumeSavedSession(
+            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
+        if (signedInSession.getMode() != expectedMode) {
+            return false;
+        }
+
+        if (signedInSession.getProblem() == null || selectedProblem == null) {
+            return false;
+        }
+
+        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
+            return false;
+        }
+
+        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -97,11 +97,17 @@ public class SeeOneAction extends DpTuGuiAction {
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
+                ts.setCourse(signedInSession.getCourse());
+                ts.setUnit(signedInSession.getUnit());
+                ts.setIsActive(signedInSession.isIsActive());
+                ts.setStartDate(signedInSession.getStartDate());
                 log.info(
-                        "Initialized SEE_ONE session with existing sessionId={} tokenPresent={} and userId={}",
+                        "Initialized SEE_ONE session with existing sessionId={}, tokenPresent={}, userId={}, hasCourse={}, hasUnit={}",
                         ts.getId(),
                         ts.getSecurityToken() != null,
-                        ts.getUserId());
+                        ts.getUserId(),
+                        ts.getCourse() != null,
+                        ts.getUnit() != null);
             } else {
                 log.warn(
                         "No signed-in session found in SplashFrame; "

--- a/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SeeOneAction.java
@@ -94,7 +94,8 @@ public class SeeOneAction extends DpTuGuiAction {
                     signedInSession != null && signedInSession.getSecurityToken() != null);
 
             if (signedInSession != null) {
-                if (canResumeSavedSession(signedInSession, Mode.SEE_ONE, problem)) {
+                if (SessionResumeMatcher.canResumeSavedSession(
+                        signedInSession, Mode.SEE_ONE, problem)) {
                     log.info(
                             "Resuming previously saved SEE_ONE sessionId={} for userId={}",
                             signedInSession.getId(),
@@ -154,22 +155,5 @@ public class SeeOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
-    }
-
-    private boolean canResumeSavedSession(
-            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
-        if (signedInSession.getMode() != expectedMode) {
-            return false;
-        }
-
-        if (signedInSession.getProblem() == null || selectedProblem == null) {
-            return false;
-        }
-
-        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
-            return false;
-        }
-
-        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/SessionResumeMatcher.java
+++ b/src/main/java/edu/regis/dptu/view/act/SessionResumeMatcher.java
@@ -1,0 +1,49 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.view.act;
+
+import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.TutoringSession;
+
+final class SessionResumeMatcher {
+
+    private SessionResumeMatcher() {}
+
+    static boolean canResumeSavedSession(
+            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
+        if (signedInSession == null || expectedMode == null || selectedProblem == null) {
+            return false;
+        }
+
+        if (signedInSession.getMode() != expectedMode) {
+            return false;
+        }
+
+        Problem savedProblem = signedInSession.getProblem();
+        if (savedProblem == null) {
+            return false;
+        }
+
+        // Require exact problem identity to avoid resuming the wrong problem of the same kind.
+        if (savedProblem.getId() != selectedProblem.getId()) {
+            return false;
+        }
+
+        if (savedProblem.getType() != selectedProblem.getType()) {
+            return false;
+        }
+
+        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
+    }
+}

--- a/src/main/java/edu/regis/dptu/view/act/SessionResumeMatcher.java
+++ b/src/main/java/edu/regis/dptu/view/act/SessionResumeMatcher.java
@@ -12,38 +12,62 @@
  */
 package edu.regis.dptu.view.act;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.regis.dptu.model.Mode;
 import edu.regis.dptu.model.Problem;
 import edu.regis.dptu.model.TutoringSession;
 
 final class SessionResumeMatcher {
 
+    private static final Logger log = LoggerFactory.getLogger(SessionResumeMatcher.class);
+
     private SessionResumeMatcher() {}
 
     static boolean canResumeSavedSession(
             TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
         if (signedInSession == null || expectedMode == null || selectedProblem == null) {
+            log.debug("Resume denied: null session/mode/problem input");
             return false;
         }
 
         if (signedInSession.getMode() != expectedMode) {
+            log.debug(
+                    "Resume denied: mode mismatch expected={} actual={}",
+                    expectedMode,
+                    signedInSession.getMode());
             return false;
         }
 
         Problem savedProblem = signedInSession.getProblem();
         if (savedProblem == null) {
+            log.debug("Resume denied: signed-in session has no problem");
             return false;
         }
 
         // Require exact problem identity to avoid resuming the wrong problem of the same kind.
         if (savedProblem.getId() != selectedProblem.getId()) {
+            log.debug(
+                    "Resume denied: problem id mismatch selected={} saved={}",
+                    selectedProblem.getId(),
+                    savedProblem.getId());
             return false;
         }
 
         if (savedProblem.getType() != selectedProblem.getType()) {
+            log.debug(
+                    "Resume denied: problem type mismatch selected={} saved={}",
+                    selectedProblem.getType(),
+                    savedProblem.getType());
             return false;
         }
 
-        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
+        boolean hasPendingProgress =
+                signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
+        if (!hasPendingProgress) {
+            log.debug("Resume denied: no pending tasks in signed-in session");
+        }
+        return hasPendingProgress;
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -92,7 +92,7 @@ public class SignInAction extends DpTuGuiAction {
                                         "Login succeeded but session data was incomplete");
                         return;
                     }
-                        TutoringSession signedInSession =
+                    TutoringSession signedInSession =
                             gson.fromJson(reply.getData(), TutoringSession.class);
                     int sessionId = signedInSession.getId();
                     String securityToken = signedInSession.getSecurityToken();

--- a/src/main/java/edu/regis/dptu/view/act/SignInAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/SignInAction.java
@@ -92,13 +92,12 @@ public class SignInAction extends DpTuGuiAction {
                                         "Login succeeded but session data was incomplete");
                         return;
                     }
-                    int sessionId = sessionJson.get("id").getAsInt();
-                    String securityToken = sessionJson.get("securityToken").getAsString();
-                    TutoringSession signedInSession = new TutoringSession(user.getUserId());
-                    signedInSession.setId(sessionId);
-                    signedInSession.setSecurityToken(securityToken);
+                        TutoringSession signedInSession =
+                            gson.fromJson(reply.getData(), TutoringSession.class);
+                    int sessionId = signedInSession.getId();
+                    String securityToken = signedInSession.getSecurityToken();
                     SplashFrame.instance().setSignedInSession(signedInSession);
-                    signedInSession.setUserId(frame.getUserId());
+                    signedInSession.setUserId(user.getUserId());
                     log.info(
                             "sessionId={} securityTokenPresent={} stored in SplashFrame for userId={}",
                             sessionId,

--- a/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
@@ -90,7 +90,8 @@ public class TeachOneAction extends DpTuGuiAction {
 
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             if (signedInSession != null) {
-                if (canResumeSavedSession(signedInSession, Mode.TEACH_ONE, problem)) {
+                if (SessionResumeMatcher.canResumeSavedSession(
+                        signedInSession, Mode.TEACH_ONE, problem)) {
                     log.info(
                             "Resuming previously saved TEACH_ONE sessionId={} for userId={}",
                             signedInSession.getId(),
@@ -175,22 +176,5 @@ public class TeachOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
-    }
-
-    private boolean canResumeSavedSession(
-            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
-        if (signedInSession.getMode() != expectedMode) {
-            return false;
-        }
-
-        if (signedInSession.getProblem() == null || selectedProblem == null) {
-            return false;
-        }
-
-        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
-            return false;
-        }
-
-        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
@@ -88,6 +88,28 @@ public class TeachOneAction extends DpTuGuiAction {
             TutoringSession ts = new TutoringSession(account, problem);
             ts.setMode(Mode.TEACH_ONE);
 
+            TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
+            if (signedInSession != null) {
+                ts.setId(signedInSession.getId());
+                ts.setSecurityToken(signedInSession.getSecurityToken());
+                ts.setUserId(signedInSession.getUserId());
+                ts.setCourse(signedInSession.getCourse());
+                ts.setUnit(signedInSession.getUnit());
+                ts.setIsActive(signedInSession.isIsActive());
+                ts.setStartDate(signedInSession.getStartDate());
+                log.info(
+                        "Initialized TEACH_ONE session with existing sessionId={}, tokenPresent={}, userId={}, hasCourse={}, hasUnit={}",
+                        ts.getId(),
+                        ts.getSecurityToken() != null,
+                        ts.getUserId(),
+                        ts.getCourse() != null,
+                        ts.getUnit() != null);
+            } else {
+                log.warn(
+                        "No signed-in session found in SplashFrame; "
+                                + "TEACH_ONE session has no authorization context (sessionId or securityToken)");
+            }
+
             /**
              * for future students, in order to initialize a tutoring session, you need to populate
              * the task list for that session none of our constructors (there are three), do this

--- a/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
+++ b/src/main/java/edu/regis/dptu/view/act/TeachOneAction.java
@@ -90,6 +90,15 @@ public class TeachOneAction extends DpTuGuiAction {
 
             TutoringSession signedInSession = SplashFrame.instance().getSignedInSession();
             if (signedInSession != null) {
+                if (canResumeSavedSession(signedInSession, Mode.TEACH_ONE, problem)) {
+                    log.info(
+                            "Resuming previously saved TEACH_ONE sessionId={} for userId={}",
+                            signedInSession.getId(),
+                            signedInSession.getUserId());
+                    SplashFrame.instance().selectLessonScreen(signedInSession);
+                    return;
+                }
+
                 ts.setId(signedInSession.getId());
                 ts.setSecurityToken(signedInSession.getSecurityToken());
                 ts.setUserId(signedInSession.getUserId());
@@ -166,5 +175,22 @@ public class TeachOneAction extends DpTuGuiAction {
                             ResourceMgr.instance().string("dialog.title.error"),
                             ResourceMgr.instance().string("error.failedToLoadProblem"));
         }
+    }
+
+    private boolean canResumeSavedSession(
+            TutoringSession signedInSession, Mode expectedMode, Problem selectedProblem) {
+        if (signedInSession.getMode() != expectedMode) {
+            return false;
+        }
+
+        if (signedInSession.getProblem() == null || selectedProblem == null) {
+            return false;
+        }
+
+        if (signedInSession.getProblem().getType() != selectedProblem.getType()) {
+            return false;
+        }
+
+        return signedInSession.getTasks() != null && !signedInSession.getTasks().isEmpty();
     }
 }

--- a/src/main/resources/Msgs.properties
+++ b/src/main/resources/Msgs.properties
@@ -185,6 +185,9 @@ action.newUser.tooltip=Request to create a new user
 action.save.name=Save
 action.save.iconAlt=Save Tutoring Session
 action.save.tooltip=Save the current tutoring session
+save.session.success=Your tutoring session has been saved.
+save.session.error.noActive=There is no active tutoring session to save.
+save.session.error.failed=Unable to save your tutoring session right now. Please try again.
 
 action.seeOne.tooltip=Start a teaching session
 action.doOne.tooltip=Start a "do one" (practice) session

--- a/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
@@ -93,6 +93,8 @@ public class SessionDAOTest {
         PreparedStatement existsStmt = mock(PreparedStatement.class);
         ResultSet existsRs = mock(ResultSet.class);
         PreparedStatement insertStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingTaskStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingStepStmt = mock(PreparedStatement.class);
         PreparedStatement insertPendingStepStmt = mock(PreparedStatement.class);
         PreparedStatement insertPendingTaskStmt = mock(PreparedStatement.class);
         ResultSet keyRs = mock(ResultSet.class);
@@ -101,11 +103,14 @@ public class SessionDAOTest {
         when(mockConnection.prepareStatement(
                         startsWith("INSERT INTO TutoringSession"), any(String[].class)))
                 .thenReturn(insertStmt);
-        when(mockConnection.prepareStatement(
-                startsWith("INSERT INTO PendingStep"), anyInt()))
-            .thenReturn(insertPendingStepStmt);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
+                .thenReturn(clearPendingTaskStmt);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingStep")))
+                .thenReturn(clearPendingStepStmt);
+        when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingStep"), anyInt()))
+                .thenReturn(insertPendingStepStmt);
         when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingTask")))
-            .thenReturn(insertPendingTaskStmt);
+                .thenReturn(insertPendingTaskStmt);
         when(existsStmt.executeQuery()).thenReturn(existsRs);
         when(existsRs.next()).thenReturn(false);
         when(insertStmt.executeUpdate()).thenReturn(1);
@@ -172,7 +177,8 @@ public class SessionDAOTest {
 
         PreparedStatement pendingStmt = mock(PreparedStatement.class);
         ResultSet pendingRs = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId"))).thenReturn(pendingStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId")))
+                .thenReturn(pendingStmt);
         when(pendingStmt.executeQuery()).thenReturn(pendingRs);
         when(pendingRs.next()).thenReturn(false);
 
@@ -207,7 +213,8 @@ public class SessionDAOTest {
         PreparedStatement pendingStmt = mock(PreparedStatement.class);
         ResultSet pendingRs = mock(ResultSet.class);
 
-        when(mockConnection.prepareStatement(startsWith("SELECT SessionId"))).thenReturn(sessionStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT SessionId")))
+                .thenReturn(sessionStmt);
         when(sessionStmt.executeQuery()).thenReturn(sessionRs);
         when(sessionRs.next()).thenReturn(true);
         when(sessionRs.getInt(1)).thenReturn(222);
@@ -219,7 +226,8 @@ public class SessionDAOTest {
         when(sessionRs.getInt(8)).thenReturn(55);
         when(sessionRs.getString(9)).thenReturn("SEE_ONE");
 
-        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId"))).thenReturn(pendingStmt);
+        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId")))
+                .thenReturn(pendingStmt);
         when(pendingStmt.executeQuery()).thenReturn(pendingRs);
         when(pendingRs.next()).thenReturn(true).thenReturn(false);
         when(pendingRs.getInt(1)).thenReturn(13);
@@ -236,7 +244,8 @@ public class SessionDAOTest {
         CourseSvc mockCourseSvc = mock(CourseSvc.class);
         ProblemSvc mockProblemSvc = mock(ProblemSvc.class);
         when(mockProblemSvc.retrieve(55)).thenReturn(problem);
-        when(mockCourseSvc.retrieveTask(eq(1), eq(13), any(Connection.class))).thenReturn(restoredTask);
+        when(mockCourseSvc.retrieveTask(eq(1), eq(13), any(Connection.class)))
+                .thenReturn(restoredTask);
 
         try (MockedStatic<ServiceFactory> mockedServiceFactory = mockStatic(ServiceFactory.class)) {
             mockedServiceFactory.when(ServiceFactory::findProblemSvc).thenReturn(mockProblemSvc);
@@ -312,13 +321,13 @@ public class SessionDAOTest {
         when(mockConnection.prepareStatement(startsWith("UPDATE TutoringSession")))
                 .thenReturn(mockStatement);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
-            .thenReturn(clearPendingTaskStmt);
+                .thenReturn(clearPendingTaskStmt);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingStep")))
-            .thenReturn(clearPendingStepStmt);
+                .thenReturn(clearPendingStepStmt);
         when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingStep"), anyInt()))
-            .thenReturn(insertPendingStepStmt);
+                .thenReturn(insertPendingStepStmt);
         when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingTask")))
-            .thenReturn(insertPendingTaskStmt);
+                .thenReturn(insertPendingTaskStmt);
         when(mockStatement.executeUpdate()).thenReturn(1);
         when(insertPendingStepStmt.executeUpdate()).thenReturn(1);
         when(insertPendingTaskStmt.executeUpdate()).thenReturn(1);
@@ -347,6 +356,20 @@ public class SessionDAOTest {
 
     @Test
     public void testDeleteSuccess() throws Exception {
+        PreparedStatement lookupStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingTaskStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingStepStmt = mock(PreparedStatement.class);
+        ResultSet lookupRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT SessionId FROM TutoringSession")))
+                .thenReturn(lookupStmt);
+        when(lookupStmt.executeQuery()).thenReturn(lookupRs);
+        when(lookupRs.next()).thenReturn(true);
+        when(lookupRs.getInt(1)).thenReturn(88);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
+                .thenReturn(clearPendingTaskStmt);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingStep")))
+                .thenReturn(clearPendingStepStmt);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM TutoringSession")))
                 .thenReturn(mockStatement);
         when(mockStatement.executeUpdate()).thenReturn(1);
@@ -359,6 +382,20 @@ public class SessionDAOTest {
 
     @Test
     public void testDeleteBadRowCountRollsBack() throws Exception {
+        PreparedStatement lookupStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingTaskStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingStepStmt = mock(PreparedStatement.class);
+        ResultSet lookupRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT SessionId FROM TutoringSession")))
+                .thenReturn(lookupStmt);
+        when(lookupStmt.executeQuery()).thenReturn(lookupRs);
+        when(lookupRs.next()).thenReturn(true);
+        when(lookupRs.getInt(1)).thenReturn(88);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
+                .thenReturn(clearPendingTaskStmt);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingStep")))
+                .thenReturn(clearPendingStepStmt);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM TutoringSession")))
                 .thenReturn(mockStatement);
         when(mockStatement.executeUpdate()).thenReturn(0);

--- a/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
@@ -35,10 +35,17 @@ import edu.regis.dptu.err.ObjNotFoundException;
 import edu.regis.dptu.model.Account;
 import edu.regis.dptu.model.CourseDigest;
 import edu.regis.dptu.model.LCSProblem;
+import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.PendingStep;
+import edu.regis.dptu.model.PendingTask;
 import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.Step;
+import edu.regis.dptu.model.StepSubType;
 import edu.regis.dptu.model.Student;
+import edu.regis.dptu.model.Task;
 import edu.regis.dptu.model.TutoringSession;
 import edu.regis.dptu.model.UnitDigest;
+import edu.regis.dptu.svc.CourseSvc;
 import edu.regis.dptu.svc.ProblemSvc;
 import edu.regis.dptu.svc.ServiceFactory;
 
@@ -73,18 +80,40 @@ public class SessionDAOTest {
     @Test
     public void testCreateSuccess() throws Exception {
         TutoringSession session = buildSession(100, "student@regis.edu");
+        session.setMode(Mode.DO_ONE);
+
+        PendingTask pendingTask = new PendingTask(new Task(13));
+        PendingStep pendingStep = new PendingStep(new Step(21, 0, StepSubType.INFO_MESSAGE));
+        pendingStep.setCurrentHintIndex(2);
+        pendingStep.setNotifyTutor(true);
+        pendingStep.setIsCompleted(true);
+        pendingTask.setCurrentStep(pendingStep);
+        session.addTask(pendingTask);
 
         PreparedStatement existsStmt = mock(PreparedStatement.class);
         ResultSet existsRs = mock(ResultSet.class);
         PreparedStatement insertStmt = mock(PreparedStatement.class);
+        PreparedStatement insertPendingStepStmt = mock(PreparedStatement.class);
+        PreparedStatement insertPendingTaskStmt = mock(PreparedStatement.class);
+        ResultSet keyRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(contains("SELECT SessionId"))).thenReturn(existsStmt);
         when(mockConnection.prepareStatement(
                         startsWith("INSERT INTO TutoringSession"), any(String[].class)))
                 .thenReturn(insertStmt);
+        when(mockConnection.prepareStatement(
+                startsWith("INSERT INTO PendingStep"), anyInt()))
+            .thenReturn(insertPendingStepStmt);
+        when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingTask")))
+            .thenReturn(insertPendingTaskStmt);
         when(existsStmt.executeQuery()).thenReturn(existsRs);
         when(existsRs.next()).thenReturn(false);
         when(insertStmt.executeUpdate()).thenReturn(1);
+        when(insertPendingStepStmt.executeUpdate()).thenReturn(1);
+        when(insertPendingTaskStmt.executeUpdate()).thenReturn(1);
+        when(insertPendingStepStmt.getGeneratedKeys()).thenReturn(keyRs);
+        when(keyRs.next()).thenReturn(true);
+        when(keyRs.getInt(1)).thenReturn(44);
 
         assertDoesNotThrow(() -> dao.create(session));
 
@@ -95,6 +124,12 @@ public class SessionDAOTest {
         verify(insertStmt).setBoolean(5, session.isIsActive());
         verify(insertStmt).setString(6, session.getProblem().getType().toString());
         verify(insertStmt).setInt(7, session.getProblem().getId());
+        verify(insertStmt).setString(8, Mode.DO_ONE.name());
+        verify(insertPendingStepStmt).setInt(1, session.getId());
+        verify(insertPendingStepStmt).setInt(2, 21);
+        verify(insertPendingTaskStmt).setInt(1, session.getId());
+        verify(insertPendingTaskStmt).setInt(2, 13);
+        verify(insertPendingTaskStmt).setInt(3, 44);
     }
 
     @Test
@@ -130,14 +165,25 @@ public class SessionDAOTest {
         when(mockResultSet.getString(2)).thenReturn("token-100");
         when(mockResultSet.getDate(3)).thenReturn(Date.valueOf("2026-03-18"));
         when(mockResultSet.getBoolean(4)).thenReturn(true);
-        when(mockResultSet.getInt(6)).thenReturn(55);
+        when(mockResultSet.getInt(5)).thenReturn(1);
+        when(mockResultSet.getInt(6)).thenReturn(1);
+        when(mockResultSet.getInt(8)).thenReturn(55);
+        when(mockResultSet.getString(9)).thenReturn("TEACH_ONE");
+
+        PreparedStatement pendingStmt = mock(PreparedStatement.class);
+        ResultSet pendingRs = mock(ResultSet.class);
+        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId"))).thenReturn(pendingStmt);
+        when(pendingStmt.executeQuery()).thenReturn(pendingRs);
+        when(pendingRs.next()).thenReturn(false);
 
         Problem problem = new LCSProblem(55, "ABC", "ABD");
+        CourseSvc mockCourseSvc = mock(CourseSvc.class);
         ProblemSvc mockProblemSvc = mock(ProblemSvc.class);
         when(mockProblemSvc.retrieve(55)).thenReturn(problem);
 
         try (MockedStatic<ServiceFactory> mockedServiceFactory = mockStatic(ServiceFactory.class)) {
             mockedServiceFactory.when(ServiceFactory::findProblemSvc).thenReturn(mockProblemSvc);
+            mockedServiceFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
 
             Account account = new Account();
             account.setUserId("student@regis.edu");
@@ -150,6 +196,67 @@ public class SessionDAOTest {
             assertTrue(result.isIsActive());
             assertNotNull(result.getProblem());
             assertEquals(55, result.getProblem().getId());
+            assertEquals(Mode.TEACH_ONE, result.getMode());
+        }
+    }
+
+    @Test
+    public void testRetrieveLoadsPendingProgress() throws Exception {
+        PreparedStatement sessionStmt = mock(PreparedStatement.class);
+        ResultSet sessionRs = mock(ResultSet.class);
+        PreparedStatement pendingStmt = mock(PreparedStatement.class);
+        ResultSet pendingRs = mock(ResultSet.class);
+
+        when(mockConnection.prepareStatement(startsWith("SELECT SessionId"))).thenReturn(sessionStmt);
+        when(sessionStmt.executeQuery()).thenReturn(sessionRs);
+        when(sessionRs.next()).thenReturn(true);
+        when(sessionRs.getInt(1)).thenReturn(222);
+        when(sessionRs.getString(2)).thenReturn("token-222");
+        when(sessionRs.getDate(3)).thenReturn(Date.valueOf("2026-03-20"));
+        when(sessionRs.getBoolean(4)).thenReturn(true);
+        when(sessionRs.getInt(5)).thenReturn(1);
+        when(sessionRs.getInt(6)).thenReturn(1);
+        when(sessionRs.getInt(8)).thenReturn(55);
+        when(sessionRs.getString(9)).thenReturn("SEE_ONE");
+
+        when(mockConnection.prepareStatement(startsWith("SELECT pt.TaskId"))).thenReturn(pendingStmt);
+        when(pendingStmt.executeQuery()).thenReturn(pendingRs);
+        when(pendingRs.next()).thenReturn(true).thenReturn(false);
+        when(pendingRs.getInt(1)).thenReturn(13);
+        when(pendingRs.getInt(2)).thenReturn(400);
+        when(pendingRs.getInt(3)).thenReturn(21);
+        when(pendingRs.getBoolean(4)).thenReturn(true);
+        when(pendingRs.getBoolean(5)).thenReturn(false);
+        when(pendingRs.getInt(6)).thenReturn(3);
+
+        Problem problem = new LCSProblem(55, "ABC", "ABD");
+        Task restoredTask = new Task(13);
+        restoredTask.addStep(new Step(21, 0, StepSubType.INFO_MESSAGE));
+
+        CourseSvc mockCourseSvc = mock(CourseSvc.class);
+        ProblemSvc mockProblemSvc = mock(ProblemSvc.class);
+        when(mockProblemSvc.retrieve(55)).thenReturn(problem);
+        when(mockCourseSvc.retrieveTask(eq(1), eq(13), any(Connection.class))).thenReturn(restoredTask);
+
+        try (MockedStatic<ServiceFactory> mockedServiceFactory = mockStatic(ServiceFactory.class)) {
+            mockedServiceFactory.when(ServiceFactory::findProblemSvc).thenReturn(mockProblemSvc);
+            mockedServiceFactory.when(ServiceFactory::findCourseSvc).thenReturn(mockCourseSvc);
+
+            Account account = new Account();
+            account.setUserId("student@regis.edu");
+            Student student = new Student(account);
+
+            TutoringSession session = dao.retrieve(student);
+
+            assertEquals(Mode.SEE_ONE, session.getMode());
+            assertEquals(1, session.getTasks().size());
+            PendingTask pendingTask = session.getCurrentTask();
+            assertEquals(13, pendingTask.getTask().getId());
+            assertNotNull(pendingTask.getCurrentStep());
+            assertEquals(21, pendingTask.getCurrentStep().getStep().getId());
+            assertEquals(3, pendingTask.getCurrentStep().getCurrentHintIndex());
+            assertTrue(pendingTask.getCurrentStep().isNotifyTutor());
+            assertFalse(pendingTask.getCurrentStep().isCompleted());
         }
     }
 
@@ -191,14 +298,40 @@ public class SessionDAOTest {
     @Test
     public void testUpdateSuccess() throws Exception {
         TutoringSession session = buildSession(88, "student@regis.edu");
+        session.setMode(Mode.SEE_ONE);
+        PendingTask pendingTask = new PendingTask(new Task(7));
+        pendingTask.setCurrentStep(new PendingStep(new Step(11, 0, StepSubType.INFO_MESSAGE)));
+        session.addTask(pendingTask);
+
+        PreparedStatement clearPendingTaskStmt = mock(PreparedStatement.class);
+        PreparedStatement clearPendingStepStmt = mock(PreparedStatement.class);
+        PreparedStatement insertPendingStepStmt = mock(PreparedStatement.class);
+        PreparedStatement insertPendingTaskStmt = mock(PreparedStatement.class);
+        ResultSet keyRs = mock(ResultSet.class);
+
         when(mockConnection.prepareStatement(startsWith("UPDATE TutoringSession")))
                 .thenReturn(mockStatement);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
+            .thenReturn(clearPendingTaskStmt);
+        when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingStep")))
+            .thenReturn(clearPendingStepStmt);
+        when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingStep"), anyInt()))
+            .thenReturn(insertPendingStepStmt);
+        when(mockConnection.prepareStatement(startsWith("INSERT INTO PendingTask")))
+            .thenReturn(insertPendingTaskStmt);
         when(mockStatement.executeUpdate()).thenReturn(1);
+        when(insertPendingStepStmt.executeUpdate()).thenReturn(1);
+        when(insertPendingTaskStmt.executeUpdate()).thenReturn(1);
+        when(insertPendingStepStmt.getGeneratedKeys()).thenReturn(keyRs);
+        when(keyRs.next()).thenReturn(true);
+        when(keyRs.getInt(1)).thenReturn(15);
 
         assertDoesNotThrow(() -> dao.update(session));
 
         verify(mockConnection).setAutoCommit(false);
         verify(mockConnection).commit();
+        verify(mockStatement).setString(5, Mode.SEE_ONE.name());
+        verify(mockStatement).setInt(6, session.getId());
     }
 
     @Test

--- a/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
@@ -97,11 +97,12 @@ public class SessionDAOTest {
         PreparedStatement clearPendingStepStmt = mock(PreparedStatement.class);
         PreparedStatement insertPendingStepStmt = mock(PreparedStatement.class);
         PreparedStatement insertPendingTaskStmt = mock(PreparedStatement.class);
+        ResultSet sessionKeyRs = mock(ResultSet.class);
         ResultSet keyRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(contains("SELECT SessionId"))).thenReturn(existsStmt);
         when(mockConnection.prepareStatement(
-                        startsWith("INSERT INTO TutoringSession"), any(String[].class)))
+                        startsWith("INSERT INTO TutoringSession"), anyInt()))
                 .thenReturn(insertStmt);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
                 .thenReturn(clearPendingTaskStmt);
@@ -114,6 +115,9 @@ public class SessionDAOTest {
         when(existsStmt.executeQuery()).thenReturn(existsRs);
         when(existsRs.next()).thenReturn(false);
         when(insertStmt.executeUpdate()).thenReturn(1);
+        when(insertStmt.getGeneratedKeys()).thenReturn(sessionKeyRs);
+        when(sessionKeyRs.next()).thenReturn(true);
+        when(sessionKeyRs.getInt(1)).thenReturn(501);
         when(insertPendingStepStmt.executeUpdate()).thenReturn(1);
         when(insertPendingTaskStmt.executeUpdate()).thenReturn(1);
         when(insertPendingStepStmt.getGeneratedKeys()).thenReturn(keyRs);
@@ -130,9 +134,10 @@ public class SessionDAOTest {
         verify(insertStmt).setString(6, session.getProblem().getType().toString());
         verify(insertStmt).setInt(7, session.getProblem().getId());
         verify(insertStmt).setString(8, Mode.DO_ONE.name());
-        verify(insertPendingStepStmt).setInt(1, session.getId());
+        assertEquals(501, session.getId());
+        verify(insertPendingStepStmt).setInt(1, 501);
         verify(insertPendingStepStmt).setInt(2, 21);
-        verify(insertPendingTaskStmt).setInt(1, session.getId());
+        verify(insertPendingTaskStmt).setInt(1, 501);
         verify(insertPendingTaskStmt).setInt(2, 13);
         verify(insertPendingTaskStmt).setInt(3, 44);
     }

--- a/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
+++ b/src/test/java/edu/regis/dptu/test/SessionDAOTest.java
@@ -101,8 +101,7 @@ public class SessionDAOTest {
         ResultSet keyRs = mock(ResultSet.class);
 
         when(mockConnection.prepareStatement(contains("SELECT SessionId"))).thenReturn(existsStmt);
-        when(mockConnection.prepareStatement(
-                        startsWith("INSERT INTO TutoringSession"), anyInt()))
+        when(mockConnection.prepareStatement(startsWith("INSERT INTO TutoringSession"), anyInt()))
                 .thenReturn(insertStmt);
         when(mockConnection.prepareStatement(startsWith("DELETE FROM PendingTask")))
                 .thenReturn(clearPendingTaskStmt);

--- a/src/test/java/edu/regis/dptu/view/act/SaveSessionActionIntegrationTest.java
+++ b/src/test/java/edu/regis/dptu/view/act/SaveSessionActionIntegrationTest.java
@@ -1,0 +1,142 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.view.act;
+
+import java.awt.event.ActionEvent;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JOptionPane;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import edu.regis.dptu.err.NonRecoverableException;
+import edu.regis.dptu.err.ObjNotFoundException;
+import edu.regis.dptu.model.TutoringSession;
+import edu.regis.dptu.svc.SessionSvc;
+import edu.regis.dptu.util.ResourceMgr;
+
+public class SaveSessionActionIntegrationTest {
+
+    @AfterEach
+    public void resetActionState() {
+        SaveSessionAction.instance().resetTestOverrides();
+    }
+
+    @Test
+    public void saveActionPersistsSessionAndShowsSuccessMessage() throws Exception {
+        SaveSessionAction action = SaveSessionAction.instance();
+        SessionSvc mockSessionSvc = mock(SessionSvc.class);
+        TutoringSession session = new TutoringSession("student@regis.edu");
+        session.setId(77);
+
+        AtomicReference<SaveSessionAction.DialogRequest> shownDialog = new AtomicReference<>();
+
+        action.setActiveSessionSupplierForTest(() -> session);
+        action.setSessionSvcSupplierForTest(() -> mockSessionSvc);
+        action.setDialogPresenterForTest(shownDialog::set);
+
+        action.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "save"));
+
+        verify(mockSessionSvc).update(session);
+        verify(mockSessionSvc, never()).create(session);
+
+        SaveSessionAction.DialogRequest dialog = shownDialog.get();
+        assertNotNull(dialog);
+        assertEquals(ResourceMgr.instance().string("save.session.success"), dialog.message());
+    }
+
+    @Test
+    public void saveActionCreatesSessionWhenUpdateReportsMissingSession() throws Exception {
+        SaveSessionAction action = SaveSessionAction.instance();
+        SessionSvc mockSessionSvc = mock(SessionSvc.class);
+        TutoringSession session = new TutoringSession("student@regis.edu");
+        session.setId(88);
+
+        doUpdateThrowNotFound(mockSessionSvc);
+
+        AtomicReference<SaveSessionAction.DialogRequest> shownDialog = new AtomicReference<>();
+
+        action.setActiveSessionSupplierForTest(() -> session);
+        action.setSessionSvcSupplierForTest(() -> mockSessionSvc);
+        action.setDialogPresenterForTest(shownDialog::set);
+
+        action.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "save"));
+
+        verify(mockSessionSvc).update(session);
+        verify(mockSessionSvc).create(session);
+
+        SaveSessionAction.DialogRequest dialog = shownDialog.get();
+        assertNotNull(dialog);
+        assertEquals(ResourceMgr.instance().string("save.session.success"), dialog.message());
+    }
+
+    @Test
+    public void saveActionShowsInfoWhenNoActiveSessionExists() {
+        SaveSessionAction action = SaveSessionAction.instance();
+
+        AtomicReference<SaveSessionAction.DialogRequest> shownDialog = new AtomicReference<>();
+        action.setActiveSessionSupplierForTest(() -> null);
+        action.setDialogPresenterForTest(shownDialog::set);
+
+        action.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "save"));
+
+        SaveSessionAction.DialogRequest dialog = shownDialog.get();
+        assertNotNull(dialog);
+        assertEquals(
+            ResourceMgr.instance().string("save.session.error.noActive"), dialog.message());
+        assertEquals(ResourceMgr.instance().string("dialog.title.information"), dialog.title());
+    }
+
+    @Test
+    public void saveActionShowsErrorWhenPersistenceFails() throws Exception {
+        SaveSessionAction action = SaveSessionAction.instance();
+        SessionSvc mockSessionSvc = mock(SessionSvc.class);
+        TutoringSession session = new TutoringSession("student@regis.edu");
+        session.setId(99);
+
+        doThrow(new NonRecoverableException("database unavailable"))
+            .when(mockSessionSvc)
+            .update(session);
+
+        AtomicReference<SaveSessionAction.DialogRequest> shownDialog = new AtomicReference<>();
+
+        action.setActiveSessionSupplierForTest(() -> session);
+        action.setSessionSvcSupplierForTest(() -> mockSessionSvc);
+        action.setDialogPresenterForTest(shownDialog::set);
+
+        action.actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "save"));
+
+        verify(mockSessionSvc).update(session);
+
+        SaveSessionAction.DialogRequest dialog = shownDialog.get();
+        assertNotNull(dialog);
+        assertEquals(ResourceMgr.instance().string("save.session.error.failed"), dialog.message());
+        assertEquals(ResourceMgr.instance().string("dialog.title.error"), dialog.title());
+        assertEquals(JOptionPane.ERROR_MESSAGE, dialog.messageType());
+    }
+
+    private void doUpdateThrowNotFound(SessionSvc mockSessionSvc) throws Exception {
+        doThrow(new ObjNotFoundException("missing session"))
+                .when(mockSessionSvc)
+                .update(any(TutoringSession.class));
+    }
+}

--- a/src/test/java/edu/regis/dptu/view/act/SaveSessionActionIntegrationTest.java
+++ b/src/test/java/edu/regis/dptu/view/act/SaveSessionActionIntegrationTest.java
@@ -102,7 +102,7 @@ public class SaveSessionActionIntegrationTest {
         SaveSessionAction.DialogRequest dialog = shownDialog.get();
         assertNotNull(dialog);
         assertEquals(
-            ResourceMgr.instance().string("save.session.error.noActive"), dialog.message());
+                ResourceMgr.instance().string("save.session.error.noActive"), dialog.message());
         assertEquals(ResourceMgr.instance().string("dialog.title.information"), dialog.title());
     }
 
@@ -114,8 +114,8 @@ public class SaveSessionActionIntegrationTest {
         session.setId(99);
 
         doThrow(new NonRecoverableException("database unavailable"))
-            .when(mockSessionSvc)
-            .update(session);
+                .when(mockSessionSvc)
+                .update(session);
 
         AtomicReference<SaveSessionAction.DialogRequest> shownDialog = new AtomicReference<>();
 

--- a/src/test/java/edu/regis/dptu/view/act/SessionResumeMatcherTest.java
+++ b/src/test/java/edu/regis/dptu/view/act/SessionResumeMatcherTest.java
@@ -1,0 +1,98 @@
+/*
+ * DPTu: Dynamic Programming Tutor
+ *
+ *  (C) Johanna & Richard Blumenthal, All rights reserved
+ *
+ *  Unauthorized use, duplication or distribution without the authors'
+ *  permission is strictly prohibited.
+ *
+ *  Unless required by applicable law or agreed to in writing, this
+ *  software is distributed on an "AS IS" basis without warranties
+ *  or conditions of any kind, either expressed or implied.
+ */
+package edu.regis.dptu.view.act;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.regis.dptu.model.Mode;
+import edu.regis.dptu.model.PendingStep;
+import edu.regis.dptu.model.PendingTask;
+import edu.regis.dptu.model.Problem;
+import edu.regis.dptu.model.Step;
+import edu.regis.dptu.model.StepSubType;
+import edu.regis.dptu.model.Task;
+import edu.regis.dptu.model.TutoringSession;
+
+public class SessionResumeMatcherTest {
+
+    @Test
+    public void resumeAllowedWhenModeProblemAndProgressMatch() {
+        Problem selectedProblem = new edu.regis.dptu.model.LCSProblem(55, "A", "B");
+        TutoringSession session = sessionWithModeAndProblem(Mode.SEE_ONE, selectedProblem);
+        session.addTask(taskWithPendingStep(13, 21));
+
+        assertTrue(
+                SessionResumeMatcher.canResumeSavedSession(session, Mode.SEE_ONE, selectedProblem));
+    }
+
+    @Test
+    public void resumeDeniedWhenProblemIdDiffersEvenIfTypeMatches() {
+        Problem savedProblem = new edu.regis.dptu.model.LCSProblem(55, "A", "B");
+        Problem selectedProblem = new edu.regis.dptu.model.LCSProblem(56, "A", "B");
+        TutoringSession session = sessionWithModeAndProblem(Mode.SEE_ONE, savedProblem);
+        session.addTask(taskWithPendingStep(13, 21));
+
+        assertFalse(
+                SessionResumeMatcher.canResumeSavedSession(session, Mode.SEE_ONE, selectedProblem));
+    }
+
+    @Test
+    public void resumeDeniedWhenModeDiffers() {
+        Problem selectedProblem = new edu.regis.dptu.model.LCSProblem(55, "A", "B");
+        TutoringSession session = sessionWithModeAndProblem(Mode.DO_ONE, selectedProblem);
+        session.addTask(taskWithPendingStep(13, 21));
+
+        assertFalse(
+                SessionResumeMatcher.canResumeSavedSession(session, Mode.SEE_ONE, selectedProblem));
+    }
+
+    @Test
+    public void resumeDeniedWhenNoPendingProgressExists() {
+        Problem selectedProblem = new edu.regis.dptu.model.LCSProblem(55, "A", "B");
+        TutoringSession session = sessionWithModeAndProblem(Mode.SEE_ONE, selectedProblem);
+
+        assertFalse(
+                SessionResumeMatcher.canResumeSavedSession(session, Mode.SEE_ONE, selectedProblem));
+    }
+
+    @Test
+    public void resumeDeniedWhenSavedProblemMissing() {
+        Problem selectedProblem = new edu.regis.dptu.model.LCSProblem(55, "A", "B");
+        TutoringSession session = new TutoringSession("student@regis.edu");
+        session.setMode(Mode.SEE_ONE);
+        session.addTask(taskWithPendingStep(13, 21));
+
+        assertFalse(
+                SessionResumeMatcher.canResumeSavedSession(session, Mode.SEE_ONE, selectedProblem));
+    }
+
+    private TutoringSession sessionWithModeAndProblem(Mode mode, Problem problem) {
+        TutoringSession session = new TutoringSession("student@regis.edu");
+        session.setMode(mode);
+        session.setProblem(problem);
+        return session;
+    }
+
+    private PendingTask taskWithPendingStep(int taskId, int stepId) {
+        Task task = new Task(taskId);
+        Step step = new Step(stepId, 0, StepSubType.INFO_MESSAGE);
+        task.addStep(step);
+
+        PendingTask pendingTask = new PendingTask(task);
+        pendingTask.setCurrentStep(new PendingStep(step));
+        return pendingTask;
+    }
+}


### PR DESCRIPTION
## Summary

This PR completes save/resume hardening for active tutoring sessions and closes the remaining risks called out in review.

### What changed

- Fixed critical persistence risk in `SessionDAO.create` by using a transaction, reading generated keys, and assigning the real `SessionId` before pending progress rows are written.
- Tightened resume selection to prevent wrong-problem restore:
  - Added shared `SessionResumeMatcher` used by `SeeOneAction`, `DoOneAction`, and `TeachOneAction`.
  - Resume now requires exact mode match plus exact problem identity (problem id + type), not just broad type-level matching.
- Added focused resume matching tests in `SessionResumeMatcherTest`.
- Updated `SessionDAOTest` to validate generated `SessionId` propagation to pending progress persistence.
- Expanded developer documentation with:
  - explicit rationale for the `Mode` column,
  - migration guidance for existing databases,
  - explanation of why single pending task/step persistence is currently a known limitation.

## Why this matters

- Prevents saving pending progress under invalid `SessionId` values.
- Prevents accidental resume into a different problem flow.
- Makes migration expectations clear for existing deployments.
- Documents current persistence limits and intended behavior for maintainers.

## Validation

- `mvn -DskipTests test-compile`
- `mvn -DskipTests spotless:check`
- `mvn "-Dtest=SessionDAOTest,SaveSessionActionIntegrationTest,SessionResumeMatcherTest" test`

All checks above passed locally.
