### PR TITLE
DPTU-186: Fix typos and improve documentation clarity across multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This project was developed as part of the CS493_X01 Senior Capstone course.
    - Populate some initial data.
 
 3. Configure Application:
-   - Edit [`DpTu.properties`](./src/main/java/resources/DpTu.properties) file with:
+   - Edit [`DpTu.properties`](./src/main/resources/DpTu.properties) file with:
      edu.regis.dptu.DB_HOST=your_mysql_host (likely `localhost`)
      edu.regis.dptu.DB_NAME=your_database_name (if using the script, then `DpTuDB`)
      edu.regis.dptu.DB_USER=your_mysql_user (if using the script, then `DpTuTs`)
@@ -148,7 +148,7 @@ When contributing, be mindful to format the code before pushing it to GitHub. Yo
 
 If you forget to format the code, be mindful that the consolidated CI workflow [`.github/workflows/format-build-test.yml`](./.github/workflows/format-build-test.yml) applies formatting on same-repository pull requests and may push an auto-format commit.
 
-A future contribution could be how to configure Netbeans to run this automatically in a pre-commit hook (but as of Sept 2025, Netbeans does not support pre-commit hooks). 
+A future contribution could be how to configure NetBeans to run this automatically in a pre-commit hook (but as of Sept 2025, NetBeans does not support pre-commit hooks). 
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When contributing, be mindful to format the code before pushing it to GitHub. Yo
 
 If you forget to format the code, be mindful that the consolidated CI workflow [`.github/workflows/format-build-test.yml`](./.github/workflows/format-build-test.yml) applies formatting on same-repository pull requests and may push an auto-format commit.
 
-A future contribution could be how to configure NetBeans to run this automatically in a pre-commit hook (but as of Sept 2025, NetBeans does not support pre-commit hooks). 
+A future contribution could be how to configure NetBeans to run this automatically in a pre-commit hook (but as of Sept 2025, NetBeans does not support pre-commit hooks).
 
 ## Known Issues
 

--- a/src/main/java/edu/regis/dptu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDAO.java
@@ -249,7 +249,9 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 // Link the exercising locations in this outcome to those in the course.
                 ArrayList<ExercisingLocation> locations = new ArrayList<>();
                 String[] ids = rs.getString(7).split(",");
-                for (int i = 0; i < ids.length; i++) locations.add(course.findLocation(i));
+                for (int i = 0; i < ids.length; i++) {
+                    locations.add(course.findLocation(Integer.parseInt(ids[i].trim())));
+                }
 
                 comp.setExercisingLocations(locations);
 
@@ -314,7 +316,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     /**
      * Extract and return the tasks in the given &lt;Unit> element
      *
-     * @param parent &lt;Unit> // ToDo is this always true?
+        * @param unit the unit whose tasks are being retrieved
      * @return a Task list.
      */
     private ArrayList<Task> retrieveTasks(Course course, Unit unit, Connection conn)
@@ -494,7 +496,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
                 log.debug("Timeout retrieved id={}", timeoutId);
                 return timeout;
             } else {
-                // ToDo: throw a dabase inconsistency error
+                // ToDo: throw a database inconsistency error
                 String errMsg = "Timeout not found, id: " + timeoutId;
                 log.warn(errMsg);
                 throw new NonRecoverableException(errMsg, new InconsistentDBException(errMsg));

--- a/src/main/java/edu/regis/dptu/dao/CourseDAO.java
+++ b/src/main/java/edu/regis/dptu/dao/CourseDAO.java
@@ -316,7 +316,7 @@ public class CourseDAO extends MySqlDAO implements CourseSvc {
     /**
      * Extract and return the tasks in the given &lt;Unit> element
      *
-        * @param unit the unit whose tasks are being retrieved
+     * @param unit the unit whose tasks are being retrieved
      * @return a Task list.
      */
     private ArrayList<Task> retrieveTasks(Course course, Unit unit, Connection conn)

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -26,14 +26,14 @@ import com.google.gson.Gson;
 
 /**
  * A Facade that standardizes requests from the GUI Client to the DpTu tutor server via a socket
- * connection with requests and replies encoded as JSon encoded object strings
+ * connection with requests and replies encoded as JSON object strings
  *
  * <p>Conceptually, this facade is part of the Swing-based GUI client.
  *
  * <p>This facade exists to facilitate a subsequent port from the Swing-based GUI to a Restful HTML
  * client. As such, it is currently a logical part of the Swing-based GUI client, but for a
  * Web-Browser client, it would be implemented as part of the Server Socket Connection, which would
- * forward the HTTML JSon HttpReqeust to the tutor using POJO message passing (i.e. method
+ * forward the HTML JSON HttpRequest to the tutor using POJO message passing (i.e. method
  * invocation).
  *
  * <p>Currently, the following request types are supported: {"request": "CreateStudentAccount",
@@ -83,7 +83,7 @@ public class SvcFacade {
     private SvcFacade() {}
 
     /**
-     * Encodes the given client request as a JSon object and sends it to the tutor returning the
+        * Encodes the given client request as a JSON object and sends it to the tutor returning the
      * tutor's reply.
      *
      * @param request the ClientRequest being sent to the tutor.
@@ -91,13 +91,12 @@ public class SvcFacade {
      */
     public TutorReply tutorRequest(ClientRequest request) {
         Gson gson = new Gson();
-        // ToDo: remove debugging stmt.
         String jsonRequest = gson.toJson(request);
-        log.info("*** jasonRequest *" + jsonRequest + "*");
+        log.debug("jsonRequest={}", jsonRequest);
 
         String jsonReply = send(jsonRequest);
 
-        log.info("*** jsonReply: " + jsonReply);
+        log.debug("jsonReply={}", jsonReply);
 
         return gson.fromJson(jsonReply, TutorReply.class);
     }
@@ -107,8 +106,8 @@ public class SvcFacade {
      *
      * <p>Communication with the SERVER occurs via the socket connection on port PORT.
      *
-     * @param request a JSon encoded ClientRequest object
-     * @return a JSon encoded TutorReply from the tutor
+    * @param request a JSON encoded ClientRequest object
+    * @return a JSON encoded TutorReply from the tutor
      */
     private String send(String request) {
         Socket client = null;
@@ -152,7 +151,7 @@ public class SvcFacade {
             }
         }
 
-        // Return this as a JSon encoded TutorReply object string.
+        // Return this as a JSON encoded TutorReply object string.
         return "{'status':':ERR','data':'A non-recoverable error occurred in the socket connection (see logs)'}";
     }
 }

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -152,6 +152,6 @@ public class SvcFacade {
         }
 
         // Return this as a JSON encoded TutorReply object string.
-        return "{'status':':ERR','data':'A non-recoverable error occurred in the socket connection (see logs)'}";
+        return "{\"status\":\":ERR\",\"data\":\"A non-recoverable error occurred in the socket connection (see logs)\"}";
     }
 }

--- a/src/main/java/edu/regis/dptu/svc/SvcFacade.java
+++ b/src/main/java/edu/regis/dptu/svc/SvcFacade.java
@@ -83,7 +83,7 @@ public class SvcFacade {
     private SvcFacade() {}
 
     /**
-        * Encodes the given client request as a JSON object and sends it to the tutor returning the
+     * Encodes the given client request as a JSON object and sends it to the tutor returning the
      * tutor's reply.
      *
      * @param request the ClientRequest being sent to the tutor.
@@ -106,8 +106,8 @@ public class SvcFacade {
      *
      * <p>Communication with the SERVER occurs via the socket connection on port PORT.
      *
-    * @param request a JSON encoded ClientRequest object
-    * @return a JSON encoded TutorReply from the tutor
+     * @param request a JSON encoded ClientRequest object
+     * @return a JSON encoded TutorReply from the tutor
      */
     private String send(String request) {
         Socket client = null;

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -169,7 +169,7 @@ public class XmlMgr {
      * <p>Scans the existing FileName_n.xml files until a file with 'n' doesn't exists and then 'n'
      * is returned.
      *
-     * @param fileName a file name with and ending underscore preceding the id, but without the id.
+    * @param fileName a file name with an ending underscore preceding the id, but without the id.
      * @return an int for the next available id.
      */
     public int nextId(String fileName) {

--- a/src/main/java/edu/regis/dptu/util/XmlMgr.java
+++ b/src/main/java/edu/regis/dptu/util/XmlMgr.java
@@ -169,7 +169,7 @@ public class XmlMgr {
      * <p>Scans the existing FileName_n.xml files until a file with 'n' doesn't exists and then 'n'
      * is returned.
      *
-    * @param fileName a file name with an ending underscore preceding the id, but without the id.
+     * @param fileName a file name with an ending underscore preceding the id, but without the id.
      * @return an int for the next available id.
      */
     public int nextId(String fileName) {

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -42,8 +42,8 @@ public class GPanel extends JPanel {
      * @param c the child component
      * @param gridX the column in which the child component is anchored
      * @param gridY the row in which the child component is anchored
-    * @param gridWidth the columns spanned by the child component in the bag
-    * @param gridHeight the rows spanned by the child component in the bag
+     * @param gridWidth the columns spanned by the child component in the bag
+     * @param gridHeight the rows spanned by the child component in the bag
      * @param weightx the amount of width scaling during panel expansion
      * @param weighty the amount of height scaling during panel expansion
      * @param anchor a GridBagConstraints anchor, e.g. NORTHWEST

--- a/src/main/java/edu/regis/dptu/view/GPanel.java
+++ b/src/main/java/edu/regis/dptu/view/GPanel.java
@@ -42,8 +42,8 @@ public class GPanel extends JPanel {
      * @param c the child component
      * @param gridX the column in which the child component is anchored
      * @param gridY the row in which the child component is anchored
-     * @param gridWidth the rows spanned by the child component in the bag
-     * @param gridHeight the cols spanned by the child component in the bag
+    * @param gridWidth the columns spanned by the child component in the bag
+    * @param gridHeight the rows spanned by the child component in the bag
      * @param weightx the amount of width scaling during panel expansion
      * @param weighty the amount of height scaling during panel expansion
      * @param anchor a GridBagConstraints anchor, e.g. NORTHWEST

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -15,8 +15,8 @@ import edu.regis.dptu.model.ProblemListener;
 /**
  * Displays the appropriate input view depending on the selected problem type.
  *
- * <p>Updated April 30, 2025: - Dynamically loads the correct input panel based on the Problem's
- * TaskKind. - Supports LCSInputView and MatrixInputView. - KnapsackInputView is scaffolded for
+ * <p>Updated April 30, 2025: - Dynamically loads the correct input panel based on the ProblemKind.
+ * - Supports LCSInputView and MatrixInputView. - KnapsackInputView is scaffolded for
  * future use. - Added null model fallback to avoid initialization errors when model not yet set.
  *
  * @author EverettCV
@@ -48,7 +48,7 @@ public class ProblemInputView extends JPanel {
                 LCSProblem lcsProblem = (LCSProblem) problem;
                 LCSInputView lcsInputView = new LCSInputView(submitListener);
                 lcsInputView.setDefaultStrings(lcsProblem.getX(), lcsProblem.getY());
-                currentPanel = new LCSInputView(submitListener);
+                currentPanel = lcsInputView;
                 break;
             case MATRIX_CHAIN:
                 ProblemInputView.log.info("Setting currentPanel to MatrixInputView");

--- a/src/main/java/edu/regis/dptu/view/ProblemInputView.java
+++ b/src/main/java/edu/regis/dptu/view/ProblemInputView.java
@@ -16,8 +16,8 @@ import edu.regis.dptu.model.ProblemListener;
  * Displays the appropriate input view depending on the selected problem type.
  *
  * <p>Updated April 30, 2025: - Dynamically loads the correct input panel based on the ProblemKind.
- * - Supports LCSInputView and MatrixInputView. - KnapsackInputView is scaffolded for
- * future use. - Added null model fallback to avoid initialization errors when model not yet set.
+ * - Supports LCSInputView and MatrixInputView. - KnapsackInputView is scaffolded for future use. -
+ * Added null model fallback to avoid initialization errors when model not yet set.
  *
  * @author EverettCV
  */

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -241,7 +241,7 @@ public class SplashFrame extends JFrame {
     /**
      * Initialize and show dashboard for the given session.
      *
-     * @param firstName - The name of this user.
+      * @param firstName the user's first name shown in the dashboard.
      */
     public void initializeDashboard(String firstName) {
 

--- a/src/main/java/edu/regis/dptu/view/SplashFrame.java
+++ b/src/main/java/edu/regis/dptu/view/SplashFrame.java
@@ -241,7 +241,7 @@ public class SplashFrame extends JFrame {
     /**
      * Initialize and show dashboard for the given session.
      *
-      * @param firstName the user's first name shown in the dashboard.
+     * @param firstName the user's first name shown in the dashboard.
      */
     public void initializeDashboard(String firstName) {
 

--- a/src/main/resources/Msgs.properties
+++ b/src/main/resources/Msgs.properties
@@ -25,7 +25,7 @@ action.createAccount.tooltip=Create a new user
 auth.error.invalidPassword=Authentication Error: Invalid Password!
 auth.error.unknownUser=Authentication Error: Unknown User ID!
 
-account.create.success=Student user account successfully created\n\nPress okay and we'll return you to the sign-in screen\n\nThen, please sign-in to the tutor using this account.
+account.create.success=Student user account successfully created\n\nPress OK and we'll return you to the sign-in screen\n\nThen, please sign in to the tutor using this account.
 account.create.error.duplicateUser=User id already exists: {0}
 
 dialog.title.information=Information


### PR DESCRIPTION
[ProblemInputView.java:45](vscode-file://vscode-app/c:/Users/harri/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Reused the configured LCSInputView instance instead of creating a second new instance before rendering.
Why necessary: the second instance discarded the default strings that had just been set, so the UI could show an uninitialized input panel.

[CourseDAO.java:249](vscode-file://vscode-app/c:/Users/harri/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Changed location lookup from loop index i to parsed IDs from the DB CSV field (with trim + parseInt).
Why necessary: using i mapped outcomes to positional indexes, not actual location IDs, which could produce incorrect or null location associations.

[SvcFacade.java:94](vscode-file://vscode-app/c:/Users/harri/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Replaced high-noise info-level debug-style logs with structured debug-level logs.
Why necessary: this reduces production log noise while preserving diagnostics, and removes a leftover debugging pattern that was not appropriate at info level.